### PR TITLE
Deploy parallel and demo apps without migration

### DIFF
--- a/pipeline/common_stages.groovy
+++ b/pipeline/common_stages.groovy
@@ -57,7 +57,7 @@ def deploy_ocp4_agnosticd(kubeconfig, cluster_version) {
   }
   sh "mkdir olm"
   sh "cp -R mig-agnosticd/4.x mig-agnosticd/${cluster_version}"
-  sh "echo 'cd mig-agnosticd/${cluster_version} && ./delete_ocp4_workshop.sh &' >> destroy_env.sh"
+  sh "echo 'cd ${WORKSPACE}/mig-agnosticd/${cluster_version} && ${WORKSPACE}/mig-agnosticd/${cluster_version}/delete_ocp4_workshop.sh &' >> destroy_env.sh"
   return {
     stage('Deploy agnosticd OCP workshop ' + cluster_version + OLM_TEXT) {
       steps_finished << 'Deploy agnosticd OCP workshop ' + cluster_version + OLM_TEXT
@@ -189,7 +189,7 @@ def deploy_ocp3_agnosticd(kubeconfig, cluster_version) {
   }
 
   sh "cp -R mig-agnosticd/3.x mig-agnosticd/${cluster_version}"
-  sh "echo 'cd mig-agnosticd/${cluster_version} && ./delete_ocp3_workshop.sh &' >> destroy_env.sh"
+  sh "echo 'cd ${WORKSPACE}/mig-agnosticd/${cluster_version} && ${WORKSPACE}/mig-agnosticd/${cluster_version}/delete_ocp3_workshop.sh &' >> destroy_env.sh"
   return {
     stage('Deploy agnosticd OCP workshop ' + cluster_version) {
       steps_finished << 'Deploy agnosticd OCP workshop ' + cluster_version
@@ -443,7 +443,7 @@ def deploy_mig_controller_on_both(
         ansiColor('xterm') {
           ansiblePlaybook(
             playbook: 'mig_controller_deploy.yml',
-            extras: "-e mig_controller_host_cluster=${mig_controller_src} -e mig_controller_ui=false",
+            extras: "-e mig_controller_host_cluster=${mig_controller_src} -e mig_controller_ui=${MIG_CONTROLLER_UI}",
             hostKeyChecking: false,
             unbuffered: true,
             colorized: true)
@@ -461,7 +461,7 @@ def deploy_mig_controller_on_both(
         ansiColor('xterm') {
           ansiblePlaybook(
             playbook: 'mig_controller_deploy.yml',
-            extras: "-e mig_controller_host_cluster=${mig_controller_dst} -e mig_controller_ui=false",
+            extras: "-e mig_controller_host_cluster=${mig_controller_dst} -e mig_controller_ui=${MIG_CONTROLLER_UI}",
             hostKeyChecking: false,
             unbuffered: true,
             colorized: true)
@@ -489,7 +489,7 @@ def execute_migration(e2e_tests, source_kubeconfig, target_kubeconfig) {
               ansiblePlaybook(
                 playbook: "${env.E2E_PLAY}",
                 hostKeyChecking: false,
-                extras: "-e 'with_migrate=false'",
+                extras: "-e 'with_migrate=${MIGRATE}'",
                 tags: "${e2e_tests[i]}",
                 unbuffered: true,
                 colorized: true)
@@ -502,7 +502,7 @@ def execute_migration(e2e_tests, source_kubeconfig, target_kubeconfig) {
               ansiblePlaybook(
                 playbook: "${env.E2E_PLAY}",
                 hostKeyChecking: false,
-                extras: "-e 'with_deploy=false'",
+                extras: "-e 'with_deploy=${DEPLOY}'",
                 tags: "${e2e_tests[i]}",
                 unbuffered: true,
                 colorized: true)

--- a/pipeline/parallel-base.groovy
+++ b/pipeline/parallel-base.groovy
@@ -57,7 +57,10 @@ booleanParam(defaultValue: false, description: 'Deploy CAM disconnected', name: 
 booleanParam(defaultValue: true, description: 'Clean up workspace after build', name: 'CLEAN_WORKSPACE'),
 booleanParam(defaultValue: false, description: 'Persistent cluster builds with fixed hostname', name: 'PERSISTENT'),
 booleanParam(defaultValue: false, description: 'Enable debugging', name: 'DEBUG'),
-booleanParam(defaultValue: true, description: 'EC2 terminate instances after build', name: 'EC2_TERMINATE_INSTANCES')])])
+booleanParam(defaultValue: true, description: 'EC2 terminate instances after build', name: 'EC2_TERMINATE_INSTANCES'),
+booleanParam(defaultValue: false, description: 'Execute applications migration', name: 'MIGRATE'),
+booleanParam(defaultValue: false, description: 'Deploy demo applications', name: 'DEPLOY'),
+booleanParam(defaultValue: false, description: 'Install mig controller UI', name: 'MIG_CONTROLLER_UI')])])
 
 // true/false build parameter that defines if we use OLM to deploy mig operator on OCP4
 USE_OLM = params.USE_OLM

--- a/pipeline/utils.groovy
+++ b/pipeline/utils.groovy
@@ -111,7 +111,9 @@ def prepare_workspace(src_version = '', dest_version = '') {
       DEST_IS_OCP3 = "false"
     }
   }
-
+  if (PERSISTENT) {
+    sh "echo ${WORKSPACE} > ${JENKINS_HOME}/lastBuild"
+  }
   OC_BINARY = "${env.WORKSPACE}/bin/oc"
   sh 'touch destroy_env.sh && chmod +x destroy_env.sh'
 }


### PR DESCRIPTION
Sprint#19

- ~~Deploy cluster pair (v3.11/v4.2) with known fixed URL/hostname, known username/password~~
- ~~Each night destroy and re-deploy, load CAM stable (latest GA)~~
- ~~Must deploy some demo apps sock-shop, robot-shop, do not migrate them~~
- ~~Must deploy CAM UI~~
