### PR TITLE
olm: Refactor deployment role to comply with konveyor upstream changes

### DIFF
--- a/roles/mig_controller_prereqs/defaults/main.yml
+++ b/roles/mig_controller_prereqs/defaults/main.yml
@@ -5,7 +5,6 @@ mig_operator_branch: "{{ lookup('env', 'MIG_OPERATOR_BRANCH') or 'master' }}"
 mig_operator_release: "{{ lookup('env', 'MIG_OPERATOR_RELEASE') or 'latest' }}"
 mig_operator_use_olm: "{{ lookup('env', 'MIG_OPERATOR_USE_OLM') or 'false' }}"
 mig_operator_use_downstream: "{{ lookup('env', 'MIG_OPERATOR_USE_DOWNSTREAM') or 'false' }}"
-mig_operator_selector: { '4.1': 'marketplace.catalogSourceConfig=ocpmigrate-operators', '4.2': 'marketplace.operatorSource=ocpmigrate-operators', 'nightly': 'marketplace.operatorSource=ocpmigrate-operators', '4.3': 'marketplace.operatorSource=ocpmigrate-operators', 'latest-4.1': 'marketplace.catalogSourceConfig=ocpmigrate-operators', 'latest-4.2': 'marketplace.operatorSource=ocpmigrate-operators', 'latest': 'marketplace.operatorSource=ocpmigrate-operators' }
 mig_controller_location: "{{ workspace }}/mig-controller"
 mig_controller_repo: "{{ lookup('env', 'MIG_CONTROLLER_REPO') or 'https://github.com/konveyor/mig-controller.git' }}"
 mig_controller_branch: "{{ lookup('env', 'MIG_CONTROLLER_BRANCH') or 'master' }}"

--- a/roles/mig_controller_prereqs/tasks/operator_olm.yml
+++ b/roles/mig_controller_prereqs/tasks/operator_olm.yml
@@ -1,5 +1,13 @@
 ---
 
+- name: "Get OLM channel"
+  import_tasks: operator_olm_get_channel.yml
+
+- debug:
+    msg:
+      - "OLM operator will subscribe using release : {{ mig_operator_release }}"
+      - "OLM operator will use subscription channel : {{ mig_operator_channel }}"
+
 - name: "Deploy using OLM upstream operator"
   import_tasks: operator_upstream_olm.yml
   when: not mig_operator_use_downstream|bool

--- a/roles/mig_controller_prereqs/tasks/operator_olm_get_channel.yml
+++ b/roles/mig_controller_prereqs/tasks/operator_olm_get_channel.yml
@@ -1,0 +1,10 @@
+- name: "Extract OLM channel based on operator release"
+  set_fact:
+    mig_operator_channel: >-
+      "{{ 'latest' if mig_operator_release == 'latest' else
+      'release-v1' if mig_operator_release is version('v1.1', '<') else
+      'release-v1.1' if mig_operator_release is version('v1.2', '<') else
+      'latest' }}"
+
+- set_fact:
+    mig_operator_channel: "{{ mig_operator_channel|replace('\"', '') }}"

--- a/roles/mig_controller_prereqs/tasks/operator_upstream_olm.yml
+++ b/roles/mig_controller_prereqs/tasks/operator_upstream_olm.yml
@@ -11,7 +11,6 @@
     - debug:
         msg:
           - "OLM cluster version: {{ olm_cluster_version }}"
-          - "Using mig operator selector: {{ mig_operator_selector[olm_cluster_version] }}"
 
     - name: "Create OperatorSource"
       k8s:
@@ -22,22 +21,25 @@
       retries: 30
       delay: 30
 
+    - name: "Define OperatorSource pod label"
+      set_fact:
+        mig_operator_label: "{{ 'marketplace.catalogSourceConfig=migration-operator' if olm_cluster_version is version('4.1', '<=') else 'marketplace.operatorSource=migration-operator' }}"
+
     - name: "Wait for OLM to reconcile OperatorSource creation"
       k8s_facts:
         kind: Pod
         namespace: openshift-marketplace
-        label_selectors: "{{ mig_operator_selector[olm_cluster_version] }}"
+        label_selectors: "{{ mig_operator_label }}"
       register: pod
       until: pod.get("resources", []) | length > 0 and true in (pod | json_query('resources[].status.containerStatuses[].ready'))
       retries: 18
       delay: 10
 
-    - name: "Confirm service availability"
+    - name: "Confirm OperatorSource service availability"
       k8s_facts:
         kind: Service
         namespace: openshift-marketplace
-        name: ocpmigrate-operators
-        label_selectors: "marketplace.catalogSourceConfig=ocpmigrate-operators"
+        name: migration-operator
       register: service
       until: "'grpc' in (service | json_query('resources[].spec.ports[].name'))"
       retries: 18
@@ -48,15 +50,16 @@
         name: "{{ mig_migration_namespace }}"
         kind: Namespace
         state: present
+        wait: yes
 
-    - name: "Get grpc_endpoint IP:port of ocpmigrate-operators service"
-      set_fact:
-        grpc_endpoint: "{{ service | json_query('resources[0].spec.clusterIP') }}:{{ service | json_query('resources[0].spec.ports[0].port') }}"
+#    - name: "Extract grpc_endpoint IP:port of migration-operator service"
+#      set_fact:
+#        grpc_endpoint: "{{ service | json_query('resources[0].spec.clusterIP') }}:{{ service | json_query('resources[0].spec.ports[0].port') }}"
 
-    - name: "Create CatalogSource"
-      k8s:
-        state: present
-        definition: "{{ lookup('template', 'mig-operator-catalogsource.yml.j2' ) }}"
+#    - name: "Create CatalogSource"
+#      k8s:
+#        state: present
+#        definition: "{{ lookup('template', 'mig-operator-catalogsource.yml.j2' ) }}"
 
     - name: "Create OperatorGroup"
       k8s:

--- a/roles/mig_controller_prereqs/tasks/operator_upstream_olm.yml
+++ b/roles/mig_controller_prereqs/tasks/operator_upstream_olm.yml
@@ -52,15 +52,6 @@
         state: present
         wait: yes
 
-#    - name: "Extract grpc_endpoint IP:port of migration-operator service"
-#      set_fact:
-#        grpc_endpoint: "{{ service | json_query('resources[0].spec.clusterIP') }}:{{ service | json_query('resources[0].spec.ports[0].port') }}"
-
-#    - name: "Create CatalogSource"
-#      k8s:
-#        state: present
-#        definition: "{{ lookup('template', 'mig-operator-catalogsource.yml.j2' ) }}"
-
     - name: "Create OperatorGroup"
       k8s:
         state: present

--- a/roles/mig_controller_prereqs/tasks/operator_upstream_olm.yml
+++ b/roles/mig_controller_prereqs/tasks/operator_upstream_olm.yml
@@ -57,6 +57,20 @@
         state: present
         definition: "{{ lookup('template', 'mig-operator-operatorgroup.yml.j2' ) }}"
 
+    - name: "Load konveyor operator package file if using latest release"
+      set_fact:
+        konveyor_pkg_file: "{{ lookup('file', '{{ mig_operator_location }}/deploy/olm-catalog/konveyor-operator/konveyor-operator.package.yaml') | from_yaml }}"
+      when: mig_operator_release == "latest"
+
+    - name: "Set operator release from currentCSV from latest channel"
+      set_fact:
+        mig_operator_latest_release: "{{ konveyor_pkg_file.channels | selectattr( 'name', 'equalto', 'latest') | map(attribute='currentCSV') | first }}"
+      when: mig_operator_release == "latest"
+
+    - debug:
+        msg: "OLM operator latest release set to : {{ mig_operator_latest_release }}"
+      when: mig_operator_release == "latest"
+
     - name: "Create Subscription"
       k8s:
         state: present

--- a/roles/mig_controller_prereqs/templates/mig-operator-catalogsource.yml.j2
+++ b/roles/mig_controller_prereqs/templates/mig-operator-catalogsource.yml.j2
@@ -2,12 +2,12 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
   labels:
-    csc-owner-name: installed-custom-openshift-migration
-    csc-owner-namespace: openshift-marketplace
-  name: installed-custom-openshift-migration
-  namespace: {{ mig_migration_namespace }}
+    opsrc-owner-name: migration-operator
+    opsrc-owner-namespace: openshift-marketplace
+  name: migration-operator
+  namespace: openshift-marketplace
 spec:
   sourceType: grpc
   address: {{ grpc_endpoint }}
-  displayName: Custom Operators
-  publisher: Custom
+  displayName: Migration Operator
+  publisher: ocp-migrate-team@redhat.com

--- a/roles/mig_controller_prereqs/templates/mig-operator-subscription.yml.j2
+++ b/roles/mig_controller_prereqs/templates/mig-operator-subscription.yml.j2
@@ -4,7 +4,7 @@ metadata:
 {% if mig_operator_use_downstream|bool is sameas true %}
   name: cam-operator
 {% else %}
-  name: mig-operator
+  name: konveyor-operator
 {% endif %}
   namespace: {{ mig_migration_namespace }}
 spec:
@@ -22,8 +22,8 @@ spec:
   sourceNamespace: openshift-marketplace
   startingCSV: cam-operator.{{ mig_operator_release }}
 {% else %}
-  name: mig-operator
-  source: installed-custom-openshift-migration
-  sourceNamespace: {{ mig_migration_namespace }}
-  startingCSV: mig-operator.{{ mig_operator_release }}
+  name: konveyor-operator
+  source: migration-operator
+  sourceNamespace: openshift-marketplace
+  startingCSV: konveyor-operator.{{ mig_operator_release }}
 {% endif %}

--- a/roles/mig_controller_prereqs/templates/mig-operator-subscription.yml.j2
+++ b/roles/mig_controller_prereqs/templates/mig-operator-subscription.yml.j2
@@ -8,13 +8,7 @@ metadata:
 {% endif %}
   namespace: {{ mig_migration_namespace }}
 spec:
-{% if mig_operator_release == 'latest' %}
-  channel: latest
-{% elif mig_operator_release is version_compare('v1.1', '<') %}
-  channel: release-v1
-{% elif mig_operator_release is version_compare('v1.2', '<') %}
-  channel: release-v1.1
-{% endif %}
+  channel: {{ mig_operator_channel }}
   installPlanApproval: Automatic
 {% if mig_operator_use_downstream|bool is sameas true %}
   name: cam-operator
@@ -25,5 +19,9 @@ spec:
   name: konveyor-operator
   source: migration-operator
   sourceNamespace: openshift-marketplace
+{% if mig_operator_latest_release is defined %}
+  startingCSV: {{ mig_operator_latest_release }}
+{% else %}
   startingCSV: konveyor-operator.{{ mig_operator_release }}
+{% endif %}
 {% endif %}


### PR DESCRIPTION
- Remove mig_operator_selector in favor of ansible dynamic variable accounting for OCP v4.1 differences (easier to maintain)
- Remove label_selector on operatorsource confirm availability task, it is enough with the service name which is a fixed name
- Added wait: yes to the namespace creation task (safer)
- Removed catalog source creation, this is redundant, the operatorsource creation takes care of bringing up the catalogsource. I left the template file in place in case we have to make exceptions for OCP 4.1 which has not been tested
- Updated templates to reflect all konveyor changes (see subscription for example)

Known issues : 

- mig-operator release-1.0 and release-1.1 branches need an updated operatorsource, basically to match master, until those branches are updated this will fail for v1.1 and v1.0
https://github.com/konveyor/mig-operator/blob/master/mig-operator-source.yaml

- mig-operator latest channel cannot use "startingCSV: konveyor-operator.latest" , this seems to be broken

UPDATE : 
release-1.0 and release-1.1 branches updated , for latest operator we now extract the startingCSV from the operator package file, latest is not a valid startinCSV any more , see : 
https://github.com/konveyor/mig-operator/pull/239

