### PR TITLE
ocp4_dump_release: Refactor on its own role

### DIFF
--- a/ocp4_dump_release.yml
+++ b/ocp4_dump_release.yml
@@ -1,7 +1,6 @@
 - hosts: localhost
   tasks:
     - include_role:
-        name: ocp4_cluster_deploy
-        tasks_from: dump_ocp4.yml
+        name: ocp4_dump_release
   vars_files:
     - "{{ playbook_dir }}/config/defaults.yml"

--- a/pipeline/common_stages.groovy
+++ b/pipeline/common_stages.groovy
@@ -46,7 +46,7 @@ def deploy_ocp4_agnosticd(kubeconfig, cluster_version) {
           colorized: true)
       }
     }
-    # Reset osrelease to 4.1.0 for ocp-preview releases, it will be ignored by agnosticd
+    // Reset osrelease to 4.1.0 for ocp-preview releases, it will be ignored by agnosticd
     osrelease = '4.1.0'
   }
 

--- a/pipeline/common_stages.groovy
+++ b/pipeline/common_stages.groovy
@@ -94,6 +94,7 @@ def deploy_ocp4_agnosticd(kubeconfig, cluster_version) {
             'env_type': "ocp4-workshop",
             'software_to_deploy': "none",
             'ocp4_installer_version': "${ocp4_installer_version}",
+            'osrelease': "${repo_version}",
             'install_ocp4': "true",
             'install_opentlc_integration': "false",
             'install_idm': "htpasswd",

--- a/pipeline/ocp4-base.groovy
+++ b/pipeline/ocp4-base.groovy
@@ -1,7 +1,7 @@
 // ocp4-base.groovy
 properties([
 parameters([
-choice(choices: ['4.1', '4.2', '4.3', 'nightly'], description: 'OCP4 version to deploy', name: 'SRC_CLUSTER_VERSION'),
+choice(choices: ['4.1', '4.2', '4.3', 'pre-4.4', 'nightly'], description: 'OCP4 version to deploy', name: 'SRC_CLUSTER_VERSION'),
 string(defaultValue: 'jenkins-ci-ocp4-base', description: 'Cluster name to deploy', name: 'CLUSTER_NAME', trim: false),
 string(defaultValue: 'mig-ci@redhat.com', description: 'Email to register the deployment', name: 'EMAIL', trim: false),
 string(defaultValue: '1', description: 'OCP4 master instance count', name: 'OCP4_MASTER_INSTANCE_COUNT', trim: false),

--- a/pipeline/parallel-base.groovy
+++ b/pipeline/parallel-base.groovy
@@ -1,7 +1,7 @@
 // parallel-base.groovy
 properties([
-parameters([choice(choices: ['3.7', '3.9', '3.10', '3.11', '4.1', '4.2', '4.3', 'nightly'], description: 'OCP version to deploy on source cluster', name: 'SRC_CLUSTER_VERSION'),
-choice(choices: ['4.3', '3.11', '3.10', '3.9', '3.7', '4.1', '4.2', 'nightly'], description: 'OCP version to deploy on destination cluster', name: 'DEST_CLUSTER_VERSION'),
+parameters([choice(choices: ['3.7', '3.9', '3.10', '3.11', '4.1', '4.2', '4.3', 'pre-4.4', 'nightly'], description: 'OCP version to deploy on source cluster', name: 'SRC_CLUSTER_VERSION'),
+choice(choices: ['4.3', '3.11', '3.10', '3.9', '3.7', '4.1', '4.2', 'pre-4.4', 'nightly'], description: 'OCP version to deploy on destination cluster', name: 'DEST_CLUSTER_VERSION'),
 string(defaultValue: 'jenkins-ci-parallel-base', description: 'Cluster name to deploy', name: 'CLUSTER_NAME', trim: false),
 string(defaultValue: 'mig-ci@redhat.com', description: 'Email to register the deployment', name: 'EMAIL', trim: false),
 string(defaultValue: '1', description: 'OCP3 master instance count', name: 'OCP3_MASTER_INSTANCE_COUNT', trim: false),

--- a/roles/ocp4_dump_release/defaults/main.yml
+++ b/roles/ocp4_dump_release/defaults/main.yml
@@ -1,0 +1,4 @@
+openshift_installer_release: "{{ lookup('env', 'OCP4_RELEASE') or 'latest' }}"
+openshift_installer_release_prefix_url: "https://mirror.openshift.com/pub/openshift-v4/clients"
+openshift_parent_dir_choices: { latest-4.1: 'ocp', latest-4.2: 'ocp', latest-4.3: 'ocp', pre-4.4: 'ocp', latest: 'ocp', nightly: 'ocp-dev-preview' }
+openshift_parent_subdir_choices: { latest-4.1: 'latest-4.1', latest-4.2: 'latest-4.2', latest-4.3: 'latest-4.3', pre-4.4: 'candidate-4.4', latest: 'latest', nightly: 'latest' }

--- a/roles/ocp4_dump_release/tasks/main.yml
+++ b/roles/ocp4_dump_release/tasks/main.yml
@@ -1,0 +1,26 @@
+- name: "Set variables to OCP4 {{ openshift_installer_release }} release"
+  set_fact:
+    openshift_installer_release_url: "{{ openshift_installer_release_prefix_url }}/{{ openshift_parent_dir_choices[openshift_installer_release] }}/{{ openshift_parent_subdir_choices[openshift_installer_release] }}/openshift-install-linux.tar.gz"
+    openshift_client_release_url: "{{ openshift_installer_release_prefix_url }}/{{ openshift_parent_dir_choices[openshift_installer_release] }}/{{ openshift_parent_subdir_choices[openshift_installer_release] }}/openshift-client-linux.tar.gz"
+
+- debug:
+    msg: 
+    - "OCP4 {{ openshift_installer_release }} installer release : {{ openshift_installer_release_url }}"
+    - "OCP4 {{ openshift_installer_release }} client release : {{ openshift_client_release_url }}"
+
+- name: "Verify {{ openshift_installer_release }} release URLs"
+  uri:
+    url: "{{ item }}"
+    method: HEAD
+  register: uri
+  until: uri.status == 200
+  retries: 6
+  delay: 10
+  loop:
+    - "{{ openshift_installer_release_url }}"
+    - "{{ openshift_client_release_url }}"
+
+- name: "Write {{ openshift_installer_release }} release to ocp4_release.yml"
+  template:
+    src: ocp4_release.yml.j2
+    dest: "{{ playbook_dir }}/ocp4_release.yml"

--- a/roles/ocp4_dump_release/templates/ocp4_release.yml.j2
+++ b/roles/ocp4_dump_release/templates/ocp4_release.yml.j2
@@ -1,0 +1,2 @@
+ocp4_installer_url: {{ openshift_installer_release_url }}
+ocp4_client_url: {{ openshift_client_release_url }}


### PR DESCRIPTION
- Fix issues with nightlies and pre-4.4 candidate releases
- Nightlies currently cover 4.5.x releases
- Pre-4.4 cover 4.4 release candidates