### PR TITLE
persistent clusters enhancements

### DIFF
--- a/pipeline/common_stages.groovy
+++ b/pipeline/common_stages.groovy
@@ -57,7 +57,7 @@ def deploy_ocp4_agnosticd(kubeconfig, cluster_version) {
   }
   sh "mkdir olm"
   sh "cp -R mig-agnosticd/4.x mig-agnosticd/${cluster_version}"
-  sh "echo 'cd ${WORKSPACE}/mig-agnosticd/${cluster_version} && ${WORKSPACE}/mig-agnosticd/${cluster_version}/delete_ocp4_workshop.sh &' >> destroy_env.sh"
+  sh "echo 'cd ${WORKSPACE}/mig-agnosticd/${cluster_version} && ./delete_ocp4_workshop.sh &' >> destroy_env.sh"
   return {
     stage('Deploy agnosticd OCP workshop ' + cluster_version + OLM_TEXT) {
       steps_finished << 'Deploy agnosticd OCP workshop ' + cluster_version + OLM_TEXT
@@ -189,7 +189,7 @@ def deploy_ocp3_agnosticd(kubeconfig, cluster_version) {
   }
 
   sh "cp -R mig-agnosticd/3.x mig-agnosticd/${cluster_version}"
-  sh "echo 'cd ${WORKSPACE}/mig-agnosticd/${cluster_version} && ${WORKSPACE}/mig-agnosticd/${cluster_version}/delete_ocp3_workshop.sh &' >> destroy_env.sh"
+  sh "echo 'cd ${WORKSPACE}/mig-agnosticd/${cluster_version} && ./delete_ocp3_workshop.sh &' >> destroy_env.sh"
   return {
     stage('Deploy agnosticd OCP workshop ' + cluster_version) {
       steps_finished << 'Deploy agnosticd OCP workshop ' + cluster_version
@@ -392,7 +392,7 @@ def deploy_mig_controller_on_both(
   mig_controller_dst) {
   // mig_controller_src boolean defines if the source cluster will host mig controller
   // mig_controller_dst boolean defines if the destination cluster will host mig controller
-  sh "echo 'cd ${WORKSPACE} && ansible-playbook s3_bucket_destroy.yml &' >> destroy_env.sh"
+  sh "echo 'ansible-playbook ${WORKSPACE}/s3_bucket_destroy.yml &' >> destroy_env.sh"
   return {
     stage('Build mig-controller image and deploy on both clusters') {
       steps_finished << 'Build mig-controller image and deploy on both clusters'

--- a/pipeline/common_stages.groovy
+++ b/pipeline/common_stages.groovy
@@ -495,6 +495,23 @@ def execute_migration(e2e_tests, source_kubeconfig, target_kubeconfig) {
                 colorized: true)
             }
           }
+
+          // Prepare clusters
+          if (E2E_DEPLOY_ONLY) {
+            withEnv([
+              "KUBECONFIG=${target_kubeconfig}",
+              "PATH+EXTRA=~/bin"]) {
+              ansiColor('xterm') {
+                ansiblePlaybook(
+                  playbook: "e2e_prepare_clusters.yml",
+                  hostKeyChecking: false,
+                  extras: "",
+                  unbuffered: true,
+                  colorized: true)
+              }
+            }
+          }
+
           if (!E2E_DEPLOY_ONLY) {
             withEnv([
               "KUBECONFIG=${target_kubeconfig}",

--- a/pipeline/common_stages.groovy
+++ b/pipeline/common_stages.groovy
@@ -392,7 +392,7 @@ def deploy_mig_controller_on_both(
   mig_controller_dst) {
   // mig_controller_src boolean defines if the source cluster will host mig controller
   // mig_controller_dst boolean defines if the destination cluster will host mig controller
-  sh "echo 'ansible-playbook s3_bucket_destroy.yml &' >> destroy_env.sh"
+  sh "echo 'cd ${WORKSPACE} && ansible-playbook s3_bucket_destroy.yml &' >> destroy_env.sh"
   return {
     stage('Build mig-controller image and deploy on both clusters') {
       steps_finished << 'Build mig-controller image and deploy on both clusters'

--- a/pipeline/common_stages.groovy
+++ b/pipeline/common_stages.groovy
@@ -489,23 +489,25 @@ def execute_migration(e2e_tests, source_kubeconfig, target_kubeconfig) {
               ansiblePlaybook(
                 playbook: "${env.E2E_PLAY}",
                 hostKeyChecking: false,
-                extras: "-e 'with_migrate=${MIGRATE}'",
+                extras: "-e 'with_migrate=false'",
                 tags: "${e2e_tests[i]}",
                 unbuffered: true,
                 colorized: true)
             }
           }
-          withEnv([
-            "KUBECONFIG=${target_kubeconfig}",
-            "PATH+EXTRA=~/bin"]) {
-            ansiColor('xterm') {
-              ansiblePlaybook(
-                playbook: "${env.E2E_PLAY}",
-                hostKeyChecking: false,
-                extras: "-e 'with_deploy=${DEPLOY}'",
-                tags: "${e2e_tests[i]}",
-                unbuffered: true,
-                colorized: true)
+          if (!E2E_DEPLOY_ONLY) {
+            withEnv([
+              "KUBECONFIG=${target_kubeconfig}",
+              "PATH+EXTRA=~/bin"]) {
+              ansiColor('xterm') {
+                ansiblePlaybook(
+                  playbook: "${env.E2E_PLAY}",
+                  hostKeyChecking: false,
+                  extras: "-e 'with_deploy=false'",
+                  tags: "${e2e_tests[i]}",
+                  unbuffered: true,
+                  colorized: true)
+              }
             }
           }
         }

--- a/pipeline/common_stages.groovy
+++ b/pipeline/common_stages.groovy
@@ -443,7 +443,7 @@ def deploy_mig_controller_on_both(
         ansiColor('xterm') {
           ansiblePlaybook(
             playbook: 'mig_controller_deploy.yml',
-            extras: "-e mig_controller_host_cluster=${mig_controller_src} -e mig_controller_ui=${MIG_CONTROLLER_UI}",
+            extras: "-e mig_controller_host_cluster=${mig_controller_src} -e mig_controller_ui=false",
             hostKeyChecking: false,
             unbuffered: true,
             colorized: true)

--- a/pipeline/parallel-base.groovy
+++ b/pipeline/parallel-base.groovy
@@ -48,6 +48,7 @@ credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.Usernam
 credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.UsernamePasswordMultiBinding', defaultValue: 'ci_ocp3_admin_credentials', description: 'Cluster admin credentials used in OCP3 deployments', name: 'OCP3_CREDENTIALS', required: true),
 credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.UsernamePasswordMultiBinding', defaultValue: 'ci_stage_registry_credentials', description: 'Stage registry credentials used in disconnected deployments', name: 'STAGE_REGISTRY_CREDENTIALS', required: true),
 booleanParam(defaultValue: true, description: 'Run e2e tests', name: 'E2E_RUN'),
+booleanParam(defaultValue: false, description: 'Deploy e2e applications only, do not migrate', name: 'E2E_DEPLOY_ONLY'),
 booleanParam(defaultValue: true, description: 'Update OCP3 cluster packages to latest', name: 'OCP3_UPDATE'),
 booleanParam(defaultValue: true, description: 'Provision glusterfs workload on OCP3', name: 'OCP3_GLUSTERFS'),
 booleanParam(defaultValue: true, description: 'Provision CEPH workload on destination cluster', name: 'CEPH'),
@@ -58,9 +59,7 @@ booleanParam(defaultValue: true, description: 'Clean up workspace after build', 
 booleanParam(defaultValue: false, description: 'Persistent cluster builds with fixed hostname', name: 'PERSISTENT'),
 booleanParam(defaultValue: false, description: 'Enable debugging', name: 'DEBUG'),
 booleanParam(defaultValue: true, description: 'EC2 terminate instances after build', name: 'EC2_TERMINATE_INSTANCES'),
-booleanParam(defaultValue: false, description: 'Execute applications migration', name: 'MIGRATE'),
-booleanParam(defaultValue: false, description: 'Deploy demo applications', name: 'DEPLOY'),
-booleanParam(defaultValue: false, description: 'Install mig controller UI', name: 'MIG_CONTROLLER_UI')])])
+booleanParam(defaultValue: false, description: 'Deploy mig controller UI on destination cluster', name: 'MIG_CONTROLLER_UI')])])
 
 // true/false build parameter that defines if we use OLM to deploy mig operator on OCP4
 USE_OLM = params.USE_OLM
@@ -82,7 +81,8 @@ OCP3_GLUSTERFS = params.OCP3_GLUSTERFS
 CEPH = params.CEPH
 // true/false deploy CAM disconnected 
 USE_DISCONNECTED = params.USE_DISCONNECTED
-
+// true/false deploy e2e apps only
+E2E_DEPLOY_ONLY = params.E2E_DEPLOY_ONLY
 
 def common_stages
 def utils

--- a/pipeline/parallel-base.groovy
+++ b/pipeline/parallel-base.groovy
@@ -48,7 +48,7 @@ credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.Usernam
 credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.UsernamePasswordMultiBinding', defaultValue: 'ci_ocp3_admin_credentials', description: 'Cluster admin credentials used in OCP3 deployments', name: 'OCP3_CREDENTIALS', required: true),
 credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.UsernamePasswordMultiBinding', defaultValue: 'ci_stage_registry_credentials', description: 'Stage registry credentials used in disconnected deployments', name: 'STAGE_REGISTRY_CREDENTIALS', required: true),
 booleanParam(defaultValue: true, description: 'Run e2e tests', name: 'E2E_RUN'),
-booleanParam(defaultValue: false, description: 'Deploy e2e applications only, do not migrate', name: 'E2E_DEPLOY_ONLY'),
+booleanParam(defaultValue: false, description: 'Deploy e2e applications and prepare clusters only, do not migrate', name: 'E2E_DEPLOY_ONLY'),
 booleanParam(defaultValue: true, description: 'Update OCP3 cluster packages to latest', name: 'OCP3_UPDATE'),
 booleanParam(defaultValue: true, description: 'Provision glusterfs workload on OCP3', name: 'OCP3_GLUSTERFS'),
 booleanParam(defaultValue: true, description: 'Provision CEPH workload on destination cluster', name: 'CEPH'),

--- a/pipeline/parallel-base.groovy
+++ b/pipeline/parallel-base.groovy
@@ -59,7 +59,7 @@ booleanParam(defaultValue: true, description: 'Clean up workspace after build', 
 booleanParam(defaultValue: false, description: 'Persistent cluster builds with fixed hostname', name: 'PERSISTENT'),
 booleanParam(defaultValue: false, description: 'Enable debugging', name: 'DEBUG'),
 booleanParam(defaultValue: true, description: 'EC2 terminate instances after build', name: 'EC2_TERMINATE_INSTANCES'),
-booleanParam(defaultValue: false, description: 'Deploy mig controller UI on destination cluster', name: 'MIG_CONTROLLER_UI')])])
+booleanParam(defaultValue: true, description: 'Deploy mig controller UI on destination cluster', name: 'MIG_CONTROLLER_UI')])])
 
 // true/false build parameter that defines if we use OLM to deploy mig operator on OCP4
 USE_OLM = params.USE_OLM

--- a/pipeline/utils.groovy
+++ b/pipeline/utils.groovy
@@ -112,7 +112,8 @@ def prepare_workspace(src_version = '', dest_version = '') {
     }
   }
   if (PERSISTENT) {
-    sh "echo ${WORKSPACE} > ${JENKINS_HOME}/lastBuild"
+    sh "mkdir -p ${JENKINS_HOME}/persistent"
+    sh "echo ${WORKSPACE} > ${JENKINS_HOME}/persistent/${CLUSTER_NAME}"
   }
   OC_BINARY = "${env.WORKSPACE}/bin/oc"
   sh 'touch destroy_env.sh && chmod +x destroy_env.sh'

--- a/scripts/persistent_cluster_destroy.sh
+++ b/scripts/persistent_cluster_destroy.sh
@@ -1,12 +1,51 @@
 #!/bin/bash
 # Locate persistent cluster build dir file and execute destroy
 PERSISTENT_DIR="/var/lib/jenkins/persistent"
+SKIP=false
 export ANSIBLE_FORCE_COLOR=true
 
-if [ $# -lt 1 ]; then
-   echo "You must supply an existing persistent cluster file name: i.e $(basename $0) my-demo-cluster"
-   exit 1
-fi
-[ ! -f ${PERSISTENT_DIR}/$1 ] && echo "${PERSISTENT_DIR}/$1 does not exist, exiting.." && exit 1
+function usage () {
+echo
+echo "Valid options are : "
+echo -e "\t-n : Name of file containing persistent cluster build directory in Jenkins: i.e $0 my-demo-cluster"
+echo -e "\t-s : Skip cluster destroy, often used during first time builds"
+echo -e "\t-d : Directory containing all persistent cluster build files, default is: ${PERSISTENT_DIR}"
+echo
+exit 1
+}
 
-cd $(cat ${PERSISTENT_DIR}/$1) && sed -i "s/&$//g" destroy_env.sh && ./destroy_env.sh
+if [ $# -lt 1 ]; then
+  usage
+fi
+
+while getopts n:d:sh opt
+do
+    case $opt in
+
+        n)
+            FILE_NAME=${OPTARG}
+            ;;
+        d)
+            PERSISTENT_DIR=${OPTARG}
+            ;;
+        s)
+            SKIP=true
+            ;;
+        h)
+            usage
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+
+[ ${SKIP} == "true" ] && echo "Skipping cluster destroy.." && exit 0
+
+[ -z "${FILE_NAME}" ] && echo "Option -n must always be set.." && usage
+
+PERSISTENT_FILE=${PERSISTENT_DIR}/${FILE_NAME}
+
+[ ! -f ${PERSISTENT_FILE} ] && echo "${PERSISTENT_FILE} does not exist, exiting.." && exit 1
+
+cd $(cat ${PERSISTENT_FILE}) && sed -i "s/&$//g" destroy_env.sh && ./destroy_env.sh

--- a/scripts/persistent_cluster_destroy.sh
+++ b/scripts/persistent_cluster_destroy.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Locate persistent cluster build dir file and execute destroy
+PERSISTENT_DIR="/var/lib/jenkins/persistent"
+export ANSIBLE_FORCE_COLOR=true
+
+if [ $# -lt 1 ]; then
+   echo "You must supply an existing persistent cluster file name: i.e $(basename $0) my-demo-cluster"
+   exit 1
+fi
+[ ! -f ${PERSISTENT_DIR}/$1 ] && echo "${PERSISTENT_DIR}/$1 does not exist, exiting.." && exit 1
+
+cd $(cat ${PERSISTENT_DIR}/$1) && sed -i "s/&$//g" destroy_env.sh && ./destroy_env.sh


### PR DESCRIPTION
- Use CLUSTER_NAME to write out location of the persistent cluster build directory for increased flexibility on multi persistent cluster deployments
- Enhanced logic to allow e2e deployment of applications and CAM configuration without migrating workloads, necessary for demo clusters
- Adjust E2E deploy only logic
- Add persistent cluster destroy script to be called for rebuild Jenkins jobs
- Depends on : https://github.com/konveyor/mig-e2e/pull/81