### PR TITLE
utils: purge e2e namespaces on persistent clusters

### DIFF
--- a/ocp_ns_destroy.yml
+++ b/ocp_ns_destroy.yml
@@ -1,0 +1,26 @@
+- hosts: localhost
+  tasks:
+    - name: "Get stuck terminating namespaces"
+      k8s_facts:
+        kind: Namespace
+        field_selectors:
+          - status.phase=Terminating
+      register: stuck_ns
+
+    - block:
+        - name: "Extract stuck namespaces"
+          set_fact:
+            stuck_ns_names: "{{ stuck_ns_names | default([]) + [item.metadata.name] }}"
+          loop: "{{ stuck_ns.resources }}"
+
+        - set_fact:
+            oc_args: "{{ '-o json | tr -d \"\\n\" | sed \"s/\\\"finalizers\\\": \\[[^]]\\+\\]/\\\"finalizers\\\": []/\"' }}"
+
+        - name: "Force delete stuck namespaces"
+          shell: "{{ oc_binary }} get namespace {{ item }} {{ oc_args }} | {{ oc_binary }} replace --raw /api/v1/namespaces/{{ item }}/finalize -f -"
+          loop: "{{ stuck_ns_names }}"
+
+      when: stuck_ns.resources | length > 0
+
+  vars_files:
+    - "{{ playbook_dir }}/config/defaults.yml"

--- a/ocp_ns_destroy.yml
+++ b/ocp_ns_destroy.yml
@@ -19,6 +19,7 @@
         - name: "Force delete stuck namespaces"
           shell: "{{ oc_binary }} get namespace {{ item }} {{ oc_args }} | {{ oc_binary }} replace --raw /api/v1/namespaces/{{ item }}/finalize -f -"
           loop: "{{ stuck_ns_names }}"
+          ignore_errors: true
 
       when: stuck_ns.resources | length > 0
 

--- a/pipeline/common_stages.groovy
+++ b/pipeline/common_stages.groovy
@@ -43,7 +43,6 @@ def deploy_ocp4_agnosticd(kubeconfig, cluster_version) {
         ansiblePlaybook(
           playbook: 'ocp4_dump_release.yml',
           hostKeyChecking: false,
-          unbuffered: true,
           colorized: true)
       }
     }
@@ -148,7 +147,6 @@ def deploy_ocp4_agnosticd(kubeconfig, cluster_version) {
             playbook: 'login.yml',
             extras: "${login_vars.join(' ')}",
             hostKeyChecking: false,
-            unbuffered: true,
             colorized: true)
         }
       }
@@ -264,7 +262,6 @@ def deploy_ocp3_agnosticd(kubeconfig, cluster_version) {
             playbook: 'login.yml',
             extras: "${login_vars.join(' ')}",
             hostKeyChecking: false,
-            unbuffered: true,
             colorized: true)
         }
     } 
@@ -306,7 +303,6 @@ def sanity_checks(kubeconfig) {
             playbook: 'ocp_sanity_check.yml',
             extras: "-e oc_binary=oc",
             hostKeyChecking: false,
-            unbuffered: true,
             colorized: true)
         }
       }
@@ -339,7 +335,6 @@ def login_cluster(
          playbook: 'login.yml',
          extras: "${ocp_login_vars.join(' ')}",
          hostKeyChecking: false,
-         unbuffered: true,
          colorized: true)
         }
     }
@@ -368,7 +363,6 @@ def cam_disconnected(
                  playbook: 'cam_disconnected_prepare.yml',
                  extras: "",
                  hostKeyChecking: false,
-                 unbuffered: true,
                  colorized: true)
              }
              ansiColor('xterm') {
@@ -376,7 +370,6 @@ def cam_disconnected(
                  playbook: 'cam_disconnected_run.yml',
                  extras: "-e validate_node_config=${validate_node_config}",
                  hostKeyChecking: false,
-                 unbuffered: true,
                  colorized: true)
              }
           }
@@ -445,7 +438,6 @@ def deploy_mig_controller_on_both(
             playbook: 'mig_controller_deploy.yml',
             extras: "-e mig_controller_host_cluster=${mig_controller_src} -e mig_controller_ui=false",
             hostKeyChecking: false,
-            unbuffered: true,
             colorized: true)
         }
       }
@@ -463,7 +455,6 @@ def deploy_mig_controller_on_both(
             playbook: 'mig_controller_deploy.yml',
             extras: "-e mig_controller_host_cluster=${mig_controller_dst} -e mig_controller_ui=${MIG_CONTROLLER_UI}",
             hostKeyChecking: false,
-            unbuffered: true,
             colorized: true)
         }
       }
@@ -491,7 +482,6 @@ def execute_migration(e2e_tests, source_kubeconfig, target_kubeconfig) {
                 hostKeyChecking: false,
                 extras: "-e 'with_migrate=false'",
                 tags: "${e2e_tests[i]}",
-                unbuffered: true,
                 colorized: true)
             }
           }
@@ -506,7 +496,6 @@ def execute_migration(e2e_tests, source_kubeconfig, target_kubeconfig) {
                   playbook: "e2e_prepare_clusters.yml",
                   hostKeyChecking: false,
                   extras: "",
-                  unbuffered: true,
                   colorized: true)
               }
             }
@@ -522,7 +511,6 @@ def execute_migration(e2e_tests, source_kubeconfig, target_kubeconfig) {
                   hostKeyChecking: false,
                   extras: "-e 'with_deploy=false'",
                   tags: "${e2e_tests[i]}",
-                  unbuffered: true,
                   colorized: true)
               }
             }

--- a/pipeline/mig-e2e-base.groovy
+++ b/pipeline/mig-e2e-base.groovy
@@ -79,7 +79,9 @@ node {
               common_stages.login_cluster("${SRC_CLUSTER_URL}", "${OCP3_ADMIN_USER}", "${OCP3_ADMIN_PASSWD}", "${SRC_CLUSTER_VERSION}", SOURCE_KUBECONFIG).call()
               common_stages.login_cluster("${DEST_CLUSTER_URL}", "${OCP4_ADMIN_USER}", "${OCP4_ADMIN_PASSWD}", "${DEST_CLUSTER_VERSION}", TARGET_KUBECONFIG).call()
              }
-        // Always ensure mig controller environment is clean before deployment
+        // Ensure no namespaces are stuck terminating
+        utils.teardown_e2e_stuck_ns(TARGET_KUBECONFIG)
+        // Ensure mig controller environment is clean before deployment
         utils.teardown_mig_controller(SOURCE_KUBECONFIG)
         utils.teardown_mig_controller(TARGET_KUBECONFIG)
 
@@ -100,7 +102,7 @@ node {
         stage('Clean Up Environment') {
           // Always attempt to remove s3 buckets
           utils.teardown_s3_bucket()
-          // Teardown e2e test namespaces
+          // Ensure e2e test namespaces are removed on destination
           utils.teardown_e2e(TARGET_KUBECONFIG)
           if (CLEAN_WORKSPACE) {
               cleanWs notFailBuild: true

--- a/pipeline/mig-e2e-base.groovy
+++ b/pipeline/mig-e2e-base.groovy
@@ -100,6 +100,8 @@ node {
         stage('Clean Up Environment') {
           // Always attempt to remove s3 buckets
           utils.teardown_s3_bucket()
+          // Teardown e2e test namespaces
+          utils.teardown_e2e(TARGET_KUBECONFIG)
           if (CLEAN_WORKSPACE) {
               cleanWs notFailBuild: true
           }

--- a/pipeline/utils.groovy
+++ b/pipeline/utils.groovy
@@ -201,6 +201,20 @@ def teardown_s3_bucket() {
   }
 }
 
+def teardown_e2e(kubeconfig) {
+  dir('mig-e2e') {
+    withEnv([ "KUBECONFIG=${kubeconfig}" ]) {
+      ansiColor('xterm') {
+        ansiblePlaybook(
+          playbook: 'e2e_destroy_all.yml',
+          hostKeyChecking: false,
+          unbuffered: true,
+          colorized: true)
+      }
+    }
+  }
+}
+
 def run_debug(kubeconfig) {
   withEnv([ "KUBECONFIG=${kubeconfig}" ]) {
     sh "${DEBUG_SCRIPT} ${DEBUG_SCRIPT_ARGS} || true"

--- a/pipeline/utils.groovy
+++ b/pipeline/utils.groovy
@@ -208,7 +208,6 @@ def teardown_e2e(kubeconfig) {
         ansiblePlaybook(
           playbook: 'e2e_destroy_all.yml',
           hostKeyChecking: false,
-          unbuffered: true,
           colorized: true)
       }
     }
@@ -221,7 +220,6 @@ def teardown_e2e_stuck_ns(kubeconfig) {
       ansiblePlaybook(
         playbook: 'ocp_ns_destroy.yml',
         hostKeyChecking: false,
-        unbuffered: true,
         colorized: true)
     }
   }

--- a/pipeline/utils.groovy
+++ b/pipeline/utils.groovy
@@ -166,7 +166,6 @@ def teardown_mig_controller(kubeconfig) {
       ansiblePlaybook(
         playbook: 'mig_controller_destroy.yml',
         hostKeyChecking: false,
-        unbuffered: true,
         colorized: true)
     }
   }
@@ -180,7 +179,6 @@ def teardown_container_image() {
         playbook: 'container_image_destroy.yml',
         hostKeyChecking: false,
         extras: "-e quayio_ci_repo=${QUAYIO_CI_REPO} -e quayio_ci_tag=${MIG_CONTROLLER_BRANCH}",
-        unbuffered: true,
         colorized: true)
     }
   }
@@ -195,7 +193,6 @@ def teardown_s3_bucket() {
       ansiblePlaybook(
         playbook: 's3_bucket_destroy.yml',
         hostKeyChecking: false,
-        unbuffered: true,
         colorized: true)
     }
   }

--- a/pipeline/utils.groovy
+++ b/pipeline/utils.groovy
@@ -215,6 +215,18 @@ def teardown_e2e(kubeconfig) {
   }
 }
 
+def teardown_e2e_stuck_ns(kubeconfig) {
+  withEnv([ "KUBECONFIG=${kubeconfig}" ]) {
+    ansiColor('xterm') {
+      ansiblePlaybook(
+        playbook: 'ocp_ns_destroy.yml',
+        hostKeyChecking: false,
+        unbuffered: true,
+        colorized: true)
+    }
+  }
+}
+
 def run_debug(kubeconfig) {
   withEnv([ "KUBECONFIG=${kubeconfig}" ]) {
     sh "${DEBUG_SCRIPT} ${DEBUG_SCRIPT_ARGS} || true"


### PR DESCRIPTION
- Add function to teardown e2e namespaces to groovy utils, it is intended to ensure the namespaces have been cleaned up at the end of each e2e run on persistent clusters
- Call teardown_e2e on destination cluster on mig-e2e-base clean up environment stage
- Add playbook to search and forcefully namespaces stuck on termination (finalizer issues)