### PR TITLE
utils: Purge non-bound PVs helper

### DIFF
--- a/ocp_pv_purge.yml
+++ b/ocp_pv_purge.yml
@@ -1,0 +1,29 @@
+- hosts: localhost
+  tasks:
+
+    - name: "Obtain all PVs"
+      k8s_facts:
+        kind: PersistentVolume
+      register: pvs
+
+    - block:
+
+        - name: "Extract non-bound PVs"
+          set_fact:
+            pvs_remove: "{{ pvs_remove | default([]) + [item.metadata.name] }}"
+          when: item.status.phase != "Bound"
+          loop: "{{ pvs.resources }}"
+
+        - name: "Remove non-bound PVs"
+          k8s:
+            kind: PersistentVolume
+            state: absent
+            name: "{{ item }}"
+          loop: "{{ pvs_remove }}"
+          when: pvs_remove is defined
+          ignore_errors: true
+
+      when: pvs.resources | length > 0
+
+  vars_files:
+    - "{{ playbook_dir }}/config/defaults.yml"

--- a/pipeline/mig-e2e-base.groovy
+++ b/pipeline/mig-e2e-base.groovy
@@ -81,6 +81,8 @@ node {
              }
         // Ensure no namespaces are stuck terminating
         utils.teardown_e2e_stuck_ns(TARGET_KUBECONFIG)
+        // Purge all non-bound pvs
+        utils.teardown_e2e_purge_pv(TARGET_KUBECONFIG)
         // Ensure mig controller environment is clean before deployment
         utils.teardown_mig_controller(SOURCE_KUBECONFIG)
         utils.teardown_mig_controller(TARGET_KUBECONFIG)

--- a/pipeline/utils.groovy
+++ b/pipeline/utils.groovy
@@ -222,6 +222,17 @@ def teardown_e2e_stuck_ns(kubeconfig) {
   }
 }
 
+def teardown_e2e_purge_pv(kubeconfig) {
+  withEnv([ "KUBECONFIG=${kubeconfig}" ]) {
+    ansiColor('xterm') {
+      ansiblePlaybook(
+        playbook: 'ocp_purge_pv.yml',
+        hostKeyChecking: false,
+        colorized: true)
+    }
+  }
+}
+
 def run_debug(kubeconfig) {
   withEnv([ "KUBECONFIG=${kubeconfig}" ]) {
     sh "${DEBUG_SCRIPT} ${DEBUG_SCRIPT_ARGS} || true"


### PR DESCRIPTION
- Add function to purge non-bound PVs before we begin migrations on
  clusters