### PR TITLE
mig_destroy: Add retries and other small fixes

### DIFF
--- a/roles/get_ocp_version/defaults/main.yml
+++ b/roles/get_ocp_version/defaults/main.yml
@@ -1,1 +1,2 @@
 ---
+show_cluster_api: false

--- a/roles/get_ocp_version/tasks/main.yml
+++ b/roles/get_ocp_version/tasks/main.yml
@@ -18,5 +18,16 @@
 - set_fact:
     cluster_version: "{{ cluster_version|replace('\"', '') }}"
 
+- block:
+
+    - name: "Extract cluster API URL"
+      shell: "{{ oc_binary }} whoami --show-server"
+      register: api_url
+
+    - debug:
+        msg: "OCP cluster API: {{ api_url.stdout }}"
+
+  when: show_cluster_api|bool
+
 - debug:
-    msg: "ocp cluster version: {{ cluster_version }}"
+    msg: "OCP cluster version: {{ cluster_version }}"

--- a/roles/mig_controller_destroy/tasks/main.yml
+++ b/roles/mig_controller_destroy/tasks/main.yml
@@ -3,6 +3,11 @@
   include_vars:
     file: "{{ playbook_dir }}/roles/mig_controller_prereqs/defaults/main.yml"
 
+- include_role:
+    name: get_ocp_version
+  vars:
+    - show_cluster_api: true
+
 - name: "Destroy {{ mig_migration_namespace }} namespace"
   k8s:
     state: absent
@@ -26,7 +31,7 @@
   with_items: "{{ velero_crds }}"
   ignore_errors: true
 
-- name: "Destroy cluster role bindings"
+- name: "Destroy CAM cluster role bindings"
   k8s:
     state: absent
     api_version: rbac.authorization.k8s.io/v1beta1
@@ -35,7 +40,7 @@
     wait: yes
   with_items: "{{ mig_cluster_role_bindings }}"
 
-- name: "Destroy manager cluster role"
+- name: "Destroy CAM cluster roles"
   k8s:
     state: absent
     api_version: rbac.authorization.k8s.io/v1beta1

--- a/roles/mig_controller_destroy/tasks/main.yml
+++ b/roles/mig_controller_destroy/tasks/main.yml
@@ -10,7 +10,11 @@
     kind: Namespace
     name: "{{ mig_migration_namespace }}"
     wait: yes
-    wait_timeout: 3600
+    wait_timeout: 300
+    register: res
+    retries: 6
+    delay: 10
+    until: res is success
 
 - name: Destroy velero CRDs
   k8s:

--- a/roles/mig_controller_destroy/tasks/main.yml
+++ b/roles/mig_controller_destroy/tasks/main.yml
@@ -11,10 +11,10 @@
     name: "{{ mig_migration_namespace }}"
     wait: yes
     wait_timeout: 300
-    register: res
-    retries: 6
-    delay: 10
-    until: res is success
+  register: res
+  retries: 6
+  delay: 10
+  until: res is success
 
 - name: Destroy velero CRDs
   k8s:

--- a/roles/mig_controller_destroy/tasks/main.yml
+++ b/roles/mig_controller_destroy/tasks/main.yml
@@ -39,6 +39,7 @@
     name: "{{ item }}"
     wait: yes
   with_items: "{{ mig_cluster_role_bindings }}"
+  ignore_errors: true
 
 - name: "Destroy CAM cluster roles"
   k8s:
@@ -48,6 +49,7 @@
     name: "{{ item }}" 
     wait: yes
   with_items: "{{ mig_cluster_roles }}"
+  ignore_errors: true
 
 - name: Destroy s3 bucket if present
   include: destroy_s3_bucket.yml

--- a/roles/mig_controller_destroy/tasks/main.yml
+++ b/roles/mig_controller_destroy/tasks/main.yml
@@ -3,7 +3,7 @@
   include_vars:
     file: "{{ playbook_dir }}/roles/mig_controller_prereqs/defaults/main.yml"
 
-- name: Destroy migration namespace
+- name: "Destroy {{ mig_migration_namespace }} namespace"
   k8s:
     state: absent
     api_version: v1
@@ -16,7 +16,7 @@
   delay: 10
   until: res is success
 
-- name: Destroy velero CRDs
+- name: "Destroy CAM CRDs"
   k8s:
     state: absent
     api_version: v1beta1
@@ -24,8 +24,9 @@
     name: "{{ item }}"
     wait: yes
   with_items: "{{ velero_crds }}"
+  ignore_errors: true
 
-- name: Destroy cluster role bindings
+- name: "Destroy cluster role bindings"
   k8s:
     state: absent
     api_version: rbac.authorization.k8s.io/v1beta1
@@ -34,7 +35,7 @@
     wait: yes
   with_items: "{{ mig_cluster_role_bindings }}"
 
-- name: Destroy manager cluster role
+- name: "Destroy manager cluster role"
   k8s:
     state: absent
     api_version: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
- Add retries to migration namespace task
- Add optional print API to get_ocp_version role
- Ignore errors removing non-existent CRDs and RBAC roles