### PR TITLE
non-olm-downstream: cache purge ignore errors

### DIFF
--- a/roles/mig_controller_prereqs/tasks/operator_downstream_non_olm.yml
+++ b/roles/mig_controller_prereqs/tasks/operator_downstream_non_olm.yml
@@ -40,6 +40,7 @@
 
     - name: "Clean up podman image cache"
       shell: "podman rmi -af"
+      ignore_errors: true
 
   become: true
   when: not mig_operator_use_disconnected|bool


### PR DESCRIPTION
- Ignore podman errors on cache cleanup