### PR TITLE
Splitting common pipeline jobs into steps

### DIFF
--- a/DEBUG-GUIDE.md
+++ b/DEBUG-GUIDE.md
@@ -1,0 +1,47 @@
+# How to decrypt Mig CI debug log?
+
+The `mig-ci` build proceeds in different steps. You can try to find details of the step that failed. If it isn't any useful, `mig-ci` also displays debug information as a separate step in the build process. This document helps users comprehend that cryptic debug log.
+
+## Navigating to the debug log 
+
+`mig-ci-robot` posts a comment on each PR after the build is finished. Navigate to the link posted in the comment. The link takes you to the full build log.
+
+You will be redirected to a dashboard that looks like this : 
+
+![mig-ci-dashboard](https://user-images.githubusercontent.com/9839757/80106700-344fb580-8548-11ea-87e6-9f7648185031.png)
+
+From the different steps above, select _Gather debug info_ step. 
+
+You will see debug information gathered from both Source and Destination clusters during the build :
+
+![mig-ci-debug-log](https://user-images.githubusercontent.com/9839757/80112871-9829ac80-854f-11ea-9670-ea92f24e1a8d.gif)
+
+## Understanding debug info
+
+Click on any of the Debug Source or Debug Destination section to collapse the full text. Following instructions work for both Source and Destination debug information.
+
+### Finding logs from pods
+
+The debug output contains logs from various relevant pods. You can search for text `Process LOGS` to find the section where logs are printed in the output.
+
+More specifically, you can search for following terms :
+
+* Mig controller logs
+* Velero logs
+* Operator logs
+
+### Finding images used for build
+
+The debug output also prints images used for the build. Search for `Image` or `Dump all images` in the log output to find the details of images used during the build.
+
+### Snapshot of openshift-migration namespace 
+
+The debug script takes a snapshot of resources running during the build. You can search for text `Print all resources` to find all the resources that were running during the build in `openshift-migration` namespace.
+
+### Finding info about Migration CRs
+
+You can find (-o yaml) output for different migration resources by searching for following terms in the output : 
+* migmigration 
+* migplan
+* migstorage
+* migcluster

--- a/mig_operator_deploy.yml
+++ b/mig_operator_deploy.yml
@@ -1,5 +1,5 @@
 - hosts: localhost
   roles:
-    - mig_controller_deploy
+    - mig_controller_prereqs
   vars_files:
     - "{{ playbook_dir }}/config/defaults.yml"

--- a/pipeline/common_stages.groovy
+++ b/pipeline/common_stages.groovy
@@ -414,7 +414,7 @@ def build_mig_controller() {
 */
 def deploy_mig_controller(kubeconfig, is_host, cluster_version) {
   return {
-    def type = 'source' if ! is_host else 'destination'
+    def type = 'source' ? ! is_host : 'destination'
     stage("Deploy mig-controller on ${type} cluster") {
       steps_finished << "Deploy mig-controller on ${type} cluster"
       
@@ -422,7 +422,7 @@ def deploy_mig_controller(kubeconfig, is_host, cluster_version) {
 
       def mig_controller_image_args = 
         "-e mig_controller_image=${MIG_CONTROLLER_IMAGE} -e mig_controller_version=${MIG_CONTROLLER_TAG}" 
-        if MIG_CONTROLLER_BUILD_CUSTOM else ""  
+        ? MIG_CONTROLLER_BUILD_CUSTOM : ""  
 
       withCredentials([
         string(credentialsId: "$EC2_SUB_USER", variable: 'SUB_USER'),
@@ -457,7 +457,7 @@ def deploy_mig_controller(kubeconfig, is_host, cluster_version) {
 */
 def deploy_mig_operator(kubeconfig, is_host, cluster_version) {
   return {
-    def type = 'source' if ! is_host else 'destination'
+    def type = 'source' ? ! is_host : 'destination'
     stage("Deploy mig-operator on ${type} cluster") {
       steps_finished << "Deploy mig-operator on ${type} cluster"
       

--- a/pipeline/common_stages.groovy
+++ b/pipeline/common_stages.groovy
@@ -500,7 +500,7 @@ def build_mig_operator() {
     directory = 'mig-operator'
     
     stage('Build mig-operator image') {
-      steps_finished << 'Buil mig-operator image'
+      steps_finished << 'Build mig-operator image'
       withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: "${QUAYIO_CREDENTIALS}", usernameVariable: 'QUAY_USERNAME', passwordVariable: 'QUAY_PASSWORD']]) {
         withEnv(["IMG=${QUAYIO_CI_REPO_OPERATOR}:PR-${MIG_OPERATOR_PR_NO}"]) {
           dir(directory) {

--- a/pipeline/common_stages.groovy
+++ b/pipeline/common_stages.groovy
@@ -425,7 +425,8 @@ def deploy_mig_controller(kubeconfig, is_host, cluster_version) {
         "-e mig_controller_image=${MIG_CONTROLLER_IMAGE} -e mig_controller_version=${MIG_CONTROLLER_TAG}" : ""
 
       def mig_controller_deployment_args = is_host ?
-        "-e mig_controller_host_cluster='true' -e mig_controller_ui=${MIG_CONTROLLER_UI}" : ""
+        "-e mig_controller_host_cluster='true' -e mig_controller_ui=${MIG_CONTROLLER_UI}" : 
+        "-e mig_controller_host_cluster='false' -e mig_controller_ui=${MIG_CONTROLLER_UI}"
 
       withCredentials([
         string(credentialsId: "$EC2_SUB_USER", variable: 'SUB_USER'),

--- a/pipeline/common_stages.groovy
+++ b/pipeline/common_stages.groovy
@@ -534,11 +534,9 @@ def build_mig_operator() {
 def execute_migration(e2e_tests, source_kubeconfig, target_kubeconfig, extra_args=null) {
   return {
     stage('Execute migration') {
-      steps_finished << 'Execute migration'
       sh "cp -r config/mig_controller.yml mig-e2e/config"
-
       for (int i = 0; i < e2e_tests.size(); i++) {
-        steps_finished << 'Execute test ' + e2e_tests[i]
+        steps_finished << 'Execute migration with test cases : ' + e2e_tests[i]
         dir('mig-e2e') {
           withEnv([
             "KUBECONFIG=${source_kubeconfig}",

--- a/pipeline/common_stages.groovy
+++ b/pipeline/common_stages.groovy
@@ -378,94 +378,113 @@ def cam_disconnected(
   }
 }
 
-def deploy_mig_controller_on_both(
-  source_kubeconfig,
-  target_kubeconfig,
-  mig_controller_src,
-  mig_controller_dst) {
-  // mig_controller_src boolean defines if the source cluster will host mig controller
-  // mig_controller_dst boolean defines if the destination cluster will host mig controller
-  sh "echo 'ansible-playbook ${WORKSPACE}/s3_bucket_destroy.yml &' >> destroy_env.sh"
+/*
+  Builds mig-controller image, pushes to Quay
+  Sets environment variables with build details
+*/
+def build_mig_controller() {
   return {
-    stage('Build mig-controller image and deploy on both clusters') {
-      steps_finished << 'Build mig-controller image and deploy on both clusters'
-      // Create custom mig-controller docker image if building a different mig-controller repo/branch
-      if ("${MIG_CONTROLLER_REPO}" != "https://github.com/konveyor/mig-controller.git" || 
-          "${MIG_CONTROLLER_BRANCH}" != "master"
-        ) {
-        withEnv(["IMG=${QUAYIO_CI_REPO}:${MIG_CONTROLLER_BRANCH}"]) {
-          dir('mig-controller') {
-            sh 'make docker-build'
-          }
+    stage('Build mig-controller image') {
+      steps_finished << 'Build mig-controller image'
+      MIG_CONTROLLER_BUILD_CUSTOM = true
+      
+      withEnv(["IMG=${QUAYIO_CI_REPO}:${MIG_CONTROLLER_BRANCH}"]) {
+        dir('mig-controller') {
+          sh 'make docker-build'
         }
-        withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: "${QUAYIO_CREDENTIALS}", usernameVariable: 'QUAY_USERNAME', passwordVariable: 'QUAY_PASSWORD']]) {
-          sh 'docker login quay.io -u $QUAY_USERNAME -p $QUAY_PASSWORD'
-        }
-        withEnv(["IMG=${QUAYIO_CI_REPO}:${MIG_CONTROLLER_BRANCH}"]) {
-          sh 'docker push $IMG'
-        }
-        // Update mig-controller image and version to custom build or assume default
-        mig_controller_img = "${QUAYIO_CI_REPO}"
-        mig_controller_tag = "${MIG_CONTROLLER_BRANCH}"
-        MIG_CONTROLLER_BUILD_CUSTOM = true
-      } else {
-          mig_controller_img = "quay.io/ocpmigrate/mig-controller"
-          mig_controller_tag = "${MIG_CONTROLLER_BRANCH}"
       }
+      withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: "${QUAYIO_CREDENTIALS}", usernameVariable: 'QUAY_USERNAME', passwordVariable: 'QUAY_PASSWORD']]) {
+        sh 'docker login quay.io -u $QUAY_USERNAME -p $QUAY_PASSWORD'
+      }
+      withEnv(["IMG=${QUAYIO_CI_REPO}:${MIG_CONTROLLER_BRANCH}"]) {
+        sh 'docker push $IMG'
+      }
+      // Update mig-controller image and version to custom build or assume default
+      MIG_CONTROLLER_IMAGE = "${QUAYIO_CI_REPO}"
+      MIG_CONTROLLER_TAG = "${MIG_CONTROLLER_BRANCH}"
+  }
+}
 
-      def SRC_USE_OLM = false
-      def DEST_USE_OLM = false
-      if (USE_OLM) {
-        if (!SRC_CLUSTER_VERSION.startsWith("3.")) {
-          SRC_USE_OLM = true
-        }
-        if (!DEST_CLUSTER_VERSION.startsWith("3.")) {
-          DEST_USE_OLM = true
-        }
-      } 
+/*
+  Deploys mig-controller on given cluster
+
+  kubeconfig [string]     : Kubeconfig location
+  is_host [string]        : Is this a host cluster?
+  cluster_version [string]: Current cluster version
+*/
+def deploy_mig_controller(kubeconfig, is_host, cluster_version) {
+  return {
+    def type = 'source' if ! is_host else 'destination'
+    stage("Deploy mig-controller on ${type} cluster") {
+      steps_finished << "Deploy mig-controller on ${type} cluster"
+      
+      SHOULD_USE_OLM = USE_OLM && !cluster_version.startsWith("3.")
+
+      def mig_controller_image_args = 
+        "-e mig_controller_image=${MIG_CONTROLLER_IMAGE} -e mig_controller_version=${MIG_CONTROLLER_TAG}" 
+        if MIG_CONTROLLER_BUILD_CUSTOM else ""  
+
       withCredentials([
         string(credentialsId: "$EC2_SUB_USER", variable: 'SUB_USER'),
         string(credentialsId: "$EC2_SUB_PASS", variable: 'SUB_PASS')])
       {
-      // Source
-      withEnv([
-          "KUBECONFIG=${source_kubeconfig}",
-          "MIG_OPERATOR_BUILD_CUSTOM=${MIG_OPERATOR_BUILD_CUSTOM}",
-          "MIG_CONTROLLER_BUILD_CUSTOM=${MIG_CONTROLLER_BUILD_CUSTOM}",
-          "MIG_OPERATOR_USE_OLM=${SRC_USE_OLM}",
-          "MIG_OPERATOR_USE_DOWNSTREAM=${USE_DOWNSTREAM}",
-          "MIG_OPERATOR_USE_DISCONNECTED=${USE_DISCONNECTED}",
-          "SUB_USER=${SUB_USER}",
-          "SUB_PASS=${SUB_PASS}",
-          "PATH+EXTRA=~/bin"]) {
-        ansiColor('xterm') {
-          ansiblePlaybook(
-            playbook: 'mig_controller_deploy.yml',
-            extras: "-e mig_controller_host_cluster=${mig_controller_src} -e mig_controller_ui=false",
-            hostKeyChecking: false,
-            colorized: true)
-        }
-      }
-      // Target
-      withEnv([
-          "KUBECONFIG=${target_kubeconfig}",
-          "MIG_OPERATOR_BUILD_CUSTOM=${MIG_OPERATOR_BUILD_CUSTOM}",
-          "MIG_CONTROLLER_BUILD_CUSTOM=${MIG_CONTROLLER_BUILD_CUSTOM}",
-          "MIG_OPERATOR_USE_OLM=${DEST_USE_OLM}",
-          "MIG_OPERATOR_USE_DOWNSTREAM=${USE_DOWNSTREAM}",
-          "MIG_OPERATOR_USE_DISCONNECTED=${USE_DISCONNECTED}",
-          "SUB_USER=${SUB_USER}",
-          "SUB_PASS=${SUB_PASS}",
-          "PATH+EXTRA=~/bin"]) {
-        ansiColor('xterm') {
-          ansiblePlaybook(
-            playbook: 'mig_controller_deploy.yml',
-            extras: "-e mig_controller_image=${mig_controller_img} -e mig_controller_version=${mig_controller_tag} -e mig_controller_host_cluster=${mig_controller_dst} -e mig_controller_ui=${MIG_CONTROLLER_UI}",
-            hostKeyChecking: false,
-            colorized: true)
+        // Target
+        withEnv([
+            "KUBECONFIG=${kubeconfig}",
+            "MIG_CONTROLLER_BUILD_CUSTOM=${MIG_CONTROLLER_BUILD_CUSTOM}",
+            "SUB_USER=${SUB_USER}",
+            "SUB_PASS=${SUB_PASS}",
+            "PATH+EXTRA=~/bin"]) {
+          ansiColor('xterm') {
+            ansiblePlaybook(
+              playbook: 'mig_controller_deploy.yml',
+              extras: "${mig_controller_image_args} -e mig_controller_host_cluster=${mig_controller_dst} -e mig_controller_ui=${MIG_CONTROLLER_UI}",
+              hostKeyChecking: false,
+              colorized: true)
+          }
         }
       }
     }
+  }
+}
+
+/*
+  Deploys mig-operator on given cluster
+
+  kubeconfig [string]     : Kubeconfig location
+  is_host [string]        : Is this a host cluster?
+  cluster_version [string]: Current cluster version
+*/
+def deploy_mig_operator(kubeconfig, is_host, cluster_version) {
+  return {
+    def type = 'source' if ! is_host else 'destination'
+    stage("Deploy mig-operator on ${type} cluster") {
+      steps_finished << "Deploy mig-operator on ${type} cluster"
+      
+      SHOULD_USE_OLM = USE_OLM && !cluster_version.startsWith("3.")
+
+      withCredentials([
+        string(credentialsId: "$EC2_SUB_USER", variable: 'SUB_USER'),
+        string(credentialsId: "$EC2_SUB_PASS", variable: 'SUB_PASS')])
+      {
+        // Target
+        withEnv([
+            "KUBECONFIG=${kubeconfig}",
+            "MIG_OPERATOR_BUILD_CUSTOM=${MIG_OPERATOR_BUILD_CUSTOM}",
+            "MIG_OPERATOR_USE_OLM=${SHOULD_USE_OLM}",
+            "MIG_OPERATOR_USE_DOWNSTREAM=${USE_DOWNSTREAM}",
+            "MIG_OPERATOR_USE_DISCONNECTED=${USE_DISCONNECTED}",
+            "SUB_USER=${SUB_USER}",
+            "SUB_PASS=${SUB_PASS}",
+            "PATH+EXTRA=~/bin"]) {
+          ansiColor('xterm') {
+            ansiblePlaybook(
+              playbook: 'mig_operator_deploy.yml',
+              hostKeyChecking: false,
+              colorized: true)
+          }
+        }
+      }
     }
   }
 }
@@ -473,14 +492,13 @@ def deploy_mig_controller_on_both(
 /*
   Builds operator images, creates Quay
   application, pushes application
-
-  directory [string] : Directory of operator repo to build
 */
-def build_custom_operator() {    
+def build_mig_operator() {    
   return {
     directory = 'mig-operator'
     
-    stage('Building mig operator PR') {
+    stage('Building mig operator image from PR') {
+      steps_finished << 'Building operator image'
       withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: "${QUAYIO_CREDENTIALS}", usernameVariable: 'QUAY_USERNAME', passwordVariable: 'QUAY_PASSWORD']]) {
         withEnv(["IMG=${QUAYIO_CI_REPO_OPERATOR}:PR-${MIG_OPERATOR_PR_NO}"]) {
           dir(directory) {

--- a/pipeline/common_stages.groovy
+++ b/pipeline/common_stages.groovy
@@ -433,6 +433,7 @@ def deploy_mig_controller(kubeconfig, is_host, cluster_version) {
         withEnv([
             "KUBECONFIG=${kubeconfig}",
             "MIG_CONTROLLER_BUILD_CUSTOM=${MIG_CONTROLLER_BUILD_CUSTOM}",
+            "MIG_OPERATOR_USE_OLM=${SHOULD_USE_OLM}",
             "SUB_USER=${SUB_USER}",
             "SUB_PASS=${SUB_PASS}",
             "PATH+EXTRA=~/bin"]) {
@@ -498,8 +499,8 @@ def build_mig_operator() {
   return {
     directory = 'mig-operator'
     
-    stage('Building mig operator image from PR') {
-      steps_finished << 'Building operator image'
+    stage('Build mig-operator image') {
+      steps_finished << 'Buil mig-operator image'
       withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: "${QUAYIO_CREDENTIALS}", usernameVariable: 'QUAY_USERNAME', passwordVariable: 'QUAY_PASSWORD']]) {
         withEnv(["IMG=${QUAYIO_CI_REPO_OPERATOR}:PR-${MIG_OPERATOR_PR_NO}"]) {
           dir(directory) {

--- a/pipeline/common_stages.groovy
+++ b/pipeline/common_stages.groovy
@@ -402,6 +402,7 @@ def build_mig_controller() {
       // Update mig-controller image and version to custom build or assume default
       MIG_CONTROLLER_IMAGE = "${QUAYIO_CI_REPO}"
       MIG_CONTROLLER_TAG = "${MIG_CONTROLLER_BRANCH}"
+    }
   }
 }
 

--- a/pipeline/mig-controller-pr-builder.groovy
+++ b/pipeline/mig-controller-pr-builder.groovy
@@ -97,7 +97,7 @@ node {
 
         stage('Clean up old environment') {
           // Always ensure mig controller environment is clean before deployment
-          sh "which ansible"
+          sh "which ansible-playbook"
           utils.teardown_mig_controller(SOURCE_KUBECONFIG)
           utils.teardown_mig_controller(TARGET_KUBECONFIG)
         }

--- a/pipeline/mig-controller-pr-builder.groovy
+++ b/pipeline/mig-controller-pr-builder.groovy
@@ -15,7 +15,7 @@ string(defaultValue: 'e2e_smoke.yml', description: 'e2e test playbook to run, se
 string(defaultValue: 'all', description: 'e2e test tags to run, see https://github.com/konveyor/mig-e2e for details, space delimited', name: 'E2E_TESTS', trim: false),
 string(defaultValue: 'latest', description: 'Mig Operator/CAM release to deploy', name: 'MIG_OPERATOR_RELEASE', trim: false),
 string(defaultValue: 'scripts/mig_debug.sh', description: 'Relative file path to debug script on MIG CI repo', name: 'DEBUG_SCRIPT', trim: false),
-string(defaultValue: '', description: 'Extra debug script arguments', name: 'DEBUG_SCRIPT_ARGS', trim: false),
+string(defaultValue: '-w -o', description: 'Extra debug script arguments', name: 'DEBUG_SCRIPT_ARGS', trim: false),
 string(defaultValue: '', description: 'PR comment string from GHPRB', name: 'COMMENT_TEXT', trim: false),
 string(defaultValue: 'quay.io/konveyor_ci/mig-controller', description: 'Repo for quay io for custom mig-controller images, only used by GHPRB', name: 'QUAYIO_CI_REPO', trim: false),
 string(defaultValue: 'quay.io/konveyor_ci/mig-operator-container', description: 'Repo for quay io for custom mig-controller images, only used by GHPRB', name: 'QUAYIO_CI_REPO_OPERATOR', trim: false),

--- a/pipeline/mig-controller-pr-builder.groovy
+++ b/pipeline/mig-controller-pr-builder.groovy
@@ -120,8 +120,8 @@ node {
         // Success or failure, always send notifications
         utils.notifyBuild(currentBuild.result)
 	if (DEBUG) {
-          utils.run_debug(SOURCE_KUBECONFIG)
-          utils.run_debug(TARGET_KUBECONFIG)
+          utils.run_debug(SOURCE_KUBECONFIG, 'Source')
+          utils.run_debug(TARGET_KUBECONFIG, 'Destination')
 	}
         stage('Clean Up Environment') {
           // Always attempt to remove s3 buckets

--- a/pipeline/mig-controller-pr-builder.groovy
+++ b/pipeline/mig-controller-pr-builder.groovy
@@ -17,7 +17,6 @@ string(defaultValue: 'latest', description: 'Mig Operator/CAM release to deploy'
 string(defaultValue: 'scripts/mig_debug.sh', description: 'Relative file path to debug script on MIG CI repo', name: 'DEBUG_SCRIPT', trim: false),
 string(defaultValue: '', description: 'Extra debug script arguments', name: 'DEBUG_SCRIPT_ARGS', trim: false),
 string(defaultValue: '', description: 'PR comment string from GHPRB', name: 'COMMENT_TEXT', trim: false),
-string(defaultValue: '', description: 'Author of PR', name: 'PR_AUTHOR', trim: false),
 string(defaultValue: 'quay.io/konveyor_ci/mig-controller', description: 'Repo for quay io for custom mig-controller images, only used by GHPRB', name: 'QUAYIO_CI_REPO', trim: false),
 string(defaultValue: 'quay.io/konveyor_ci/mig-operator-container', description: 'Repo for quay io for custom mig-controller images, only used by GHPRB', name: 'QUAYIO_CI_REPO_OPERATOR', trim: false),
 string(defaultValue: '/opt/virtualenvs/python3-operator/venv/bin/operator-courier', description: 'Operator courier binary', name: 'MIG_CI_OPERATOR_COURIER_BINARY', trim: false),

--- a/pipeline/mig-controller-pr-builder.groovy
+++ b/pipeline/mig-controller-pr-builder.groovy
@@ -45,7 +45,6 @@ def CLEAN_WORKSPACE = params.CLEAN_WORKSPACE
 def E2E_TESTS = params.E2E_TESTS.split(' ')
 // true/false enable debugging
 def DEBUG = params.DEBUG
-def PR_AUTHOR = params.PR_AUTHOR
 def PERSISTENT = params.PERSISTENT
 def common_stages
 def utils

--- a/pipeline/mig-controller-pr-builder.groovy
+++ b/pipeline/mig-controller-pr-builder.groovy
@@ -46,6 +46,7 @@ def CLEAN_WORKSPACE = params.CLEAN_WORKSPACE
 def E2E_TESTS = params.E2E_TESTS.split(' ')
 // true/false enable debugging
 def DEBUG = params.DEBUG
+def PR_AUTHOR = params.PR_AUTHOR
 def PERSISTENT = params.PERSISTENT
 def common_stages
 def utils

--- a/pipeline/mig-controller-pr-builder.groovy
+++ b/pipeline/mig-controller-pr-builder.groovy
@@ -87,8 +87,7 @@ node {
           common_stages.build_mig_operator().call()
         }
         
-        stage('Clean up old environment') {
-          withCredentials([
+        withCredentials([
             [$class: 'UsernamePasswordMultiBinding', credentialsId: "${OCP3_CREDENTIALS}", usernameVariable: 'OCP3_ADMIN_USER', passwordVariable: 'OCP3_ADMIN_PASSWD'],
             [$class: 'UsernamePasswordMultiBinding', credentialsId: "${OCP4_CREDENTIALS}", usernameVariable: 'OCP4_ADMIN_USER', passwordVariable: 'OCP4_ADMIN_PASSWD']
             ]) {
@@ -96,7 +95,9 @@ node {
                 common_stages.login_cluster("${DEST_CLUSTER_URL}", "${OCP4_ADMIN_USER}", "${OCP4_ADMIN_PASSWD}", "${DEST_CLUSTER_VERSION}", TARGET_KUBECONFIG).call()
                }
 
+        stage('Clean up old environment') {
           // Always ensure mig controller environment is clean before deployment
+          sh "which ansible"
           utils.teardown_mig_controller(SOURCE_KUBECONFIG)
           utils.teardown_mig_controller(TARGET_KUBECONFIG)
         }

--- a/pipeline/mig-controller-pr-builder.groovy
+++ b/pipeline/mig-controller-pr-builder.groovy
@@ -67,6 +67,14 @@ node {
 
         utils.parse_comment_message(COMMENT_TEXT)
 
+        // prepare for tests
+        stage('Setup e2e environment') {
+            steps_finished << 'Setup e2e environment'
+
+            utils.prepare_workspace(SRC_CLUSTER_VERSION, DEST_CLUSTER_VERSION)
+            utils.clone_mig_e2e()
+        }
+
         // login to cluster
         withCredentials([
             [$class: 'UsernamePasswordMultiBinding', credentialsId: "${OCP3_CREDENTIALS}", usernameVariable: 'OCP3_ADMIN_USER', passwordVariable: 'OCP3_ADMIN_PASSWD'],
@@ -76,12 +84,8 @@ node {
                 common_stages.login_cluster("${DEST_CLUSTER_URL}", "${OCP4_ADMIN_USER}", "${OCP4_ADMIN_PASSWD}", "${DEST_CLUSTER_VERSION}", TARGET_KUBECONFIG).call()
                }
 
-        // prepare for tests
-        stage('Setup e2e environment') {
-            steps_finished << 'Setup e2e environment'
-
-            utils.prepare_workspace(SRC_CLUSTER_VERSION, DEST_CLUSTER_VERSION)
-            utils.clone_mig_e2e()
+        // clean up old stuff
+        stage('Prepare for tests') {
             utils.teardown_mig_controller(SOURCE_KUBECONFIG)
             utils.teardown_mig_controller(TARGET_KUBECONFIG)
         }

--- a/pipeline/mig-controller-pr-builder.groovy
+++ b/pipeline/mig-controller-pr-builder.groovy
@@ -31,7 +31,7 @@ booleanParam(defaultValue: false, description: 'Deploy e2e applications and prep
 booleanParam(defaultValue: true, description: 'Deploy mig controller UI on destination cluster', name: 'MIG_CONTROLLER_UI'),
 booleanParam(defaultValue: true, description: 'Deploy mig operator using OLM on OCP4', name: 'USE_OLM'),
 booleanParam(defaultValue: false, description: 'Deploy using downstream images', name: 'USE_DOWNSTREAM'),
-booleanParam(defaultValue: false, description: 'Enable debugging', name: 'DEBUG'),
+booleanParam(defaultValue: true, description: 'Enable debugging', name: 'DEBUG'),
 booleanParam(defaultValue: true, description: 'Clean up workspace after build', name: 'CLEAN_WORKSPACE')])])
 
 

--- a/pipeline/mig-controller-pr-builder.groovy
+++ b/pipeline/mig-controller-pr-builder.groovy
@@ -17,6 +17,7 @@ string(defaultValue: 'latest', description: 'Mig Operator/CAM release to deploy'
 string(defaultValue: 'scripts/mig_debug.sh', description: 'Relative file path to debug script on MIG CI repo', name: 'DEBUG_SCRIPT', trim: false),
 string(defaultValue: '', description: 'Extra debug script arguments', name: 'DEBUG_SCRIPT_ARGS', trim: false),
 string(defaultValue: '', description: 'PR comment string from GHPRB', name: 'COMMENT_TEXT', trim: false),
+string(defaultValue: '', description: 'Author of PR', name: 'PR_AUTHOR', trim: false),
 string(defaultValue: 'quay.io/konveyor_ci/mig-controller', description: 'Repo for quay io for custom mig-controller images, only used by GHPRB', name: 'QUAYIO_CI_REPO', trim: false),
 string(defaultValue: 'quay.io/konveyor_ci/mig-operator-container', description: 'Repo for quay io for custom mig-controller images, only used by GHPRB', name: 'QUAYIO_CI_REPO_OPERATOR', trim: false),
 string(defaultValue: '/opt/virtualenvs/python3-operator/venv/bin/operator-courier', description: 'Operator courier binary', name: 'MIG_CI_OPERATOR_COURIER_BINARY', trim: false),
@@ -46,8 +47,6 @@ def E2E_TESTS = params.E2E_TESTS.split(' ')
 // true/false enable debugging
 def DEBUG = params.DEBUG
 def PERSISTENT = params.PERSISTENT
-// the original person who opened this PR 
-PR_AUTHOR = params.PR_AUTHOR ? params.PR_AUTHOR : null
 def common_stages
 def utils
 

--- a/pipeline/mig-controller-pr-builder.groovy
+++ b/pipeline/mig-controller-pr-builder.groovy
@@ -47,7 +47,7 @@ def E2E_TESTS = params.E2E_TESTS.split(' ')
 def DEBUG = params.DEBUG
 def PERSISTENT = params.PERSISTENT
 // the original person who opened this PR 
-def PR_AUTHOR = params.PR_AUTHOR
+def PR_AUTHOR = params.PR_AUTHOR ? params.PR_AUTHOR : null
 def common_stages
 def utils
 

--- a/pipeline/mig-controller-pr-builder.groovy
+++ b/pipeline/mig-controller-pr-builder.groovy
@@ -46,6 +46,8 @@ def E2E_TESTS = params.E2E_TESTS.split(' ')
 // true/false enable debugging
 def DEBUG = params.DEBUG
 def PERSISTENT = params.PERSISTENT
+// the original person who opened this PR 
+def PR_AUTHOR = params.PR_AUTHOR
 def common_stages
 def utils
 

--- a/pipeline/mig-controller-pr-builder.groovy
+++ b/pipeline/mig-controller-pr-builder.groovy
@@ -47,7 +47,7 @@ def E2E_TESTS = params.E2E_TESTS.split(' ')
 def DEBUG = params.DEBUG
 def PERSISTENT = params.PERSISTENT
 // the original person who opened this PR 
-def PR_AUTHOR = params.PR_AUTHOR ? params.PR_AUTHOR : null
+PR_AUTHOR = params.PR_AUTHOR ? params.PR_AUTHOR : null
 def common_stages
 def utils
 

--- a/pipeline/mig-controller-pr-builder.groovy
+++ b/pipeline/mig-controller-pr-builder.groovy
@@ -119,10 +119,13 @@ node {
     } finally {
         // Success or failure, always send notifications
         utils.notifyBuild(currentBuild.result)
-	if (DEBUG) {
-          utils.run_debug(SOURCE_KUBECONFIG, 'Source')
-          utils.run_debug(TARGET_KUBECONFIG, 'Destination')
-	}
+	      if (DEBUG) {
+          stage('Gather debug info from both environments') {
+            utils.run_debug(SOURCE_KUBECONFIG, 'Source')
+            utils.run_debug(TARGET_KUBECONFIG, 'Destination')
+          }
+	      }
+        
         stage('Clean Up Environment') {
           // Always attempt to remove s3 buckets
           utils.teardown_s3_bucket()

--- a/pipeline/mig-e2e-base.groovy
+++ b/pipeline/mig-e2e-base.groovy
@@ -100,7 +100,7 @@ node {
         // deploy mig-operator and mig-controller on destination
         common_stages.deploy_mig_operator(TARGET_KUBECONFIG, true, DEST_CLUSTER_VERSION).call()
         common_stages.deploy_mig_controller(TARGET_KUBECONFIG, true, DEST_CLUSTER_VERSION).call()
-        
+
         common_stages.execute_migration(E2E_TESTS, SOURCE_KUBECONFIG, TARGET_KUBECONFIG).call()
 
     } catch (Exception ex) {
@@ -110,8 +110,8 @@ node {
         // Success or failure, always send notifications
         utils.notifyBuild(currentBuild.result)
 	if (DEBUG) {
-          utils.run_debug(SOURCE_KUBECONFIG)
-          utils.run_debug(TARGET_KUBECONFIG)
+          utils.run_debug(SOURCE_KUBECONFIG, 'Source')
+          utils.run_debug(TARGET_KUBECONFIG, 'Destination')
 	}
         stage('Clean Up Environment') {
           // Always attempt to remove s3 buckets

--- a/pipeline/parallel-base.groovy
+++ b/pipeline/parallel-base.groovy
@@ -166,7 +166,7 @@ node {
         utils.notifyBuild(currentBuild.result)
         if (DEBUG) {
           utils.run_debug(SOURCE_KUBECONFIG, 'Source')
-          utils.run_debug(TARGET_KUBECONFIG, 'Target')
+          utils.run_debug(TARGET_KUBECONFIG, 'Destination')
 	}
 
         stage('Clean Up Environment') {

--- a/pipeline/utils.groovy
+++ b/pipeline/utils.groovy
@@ -39,7 +39,7 @@ def notifyBuild(String buildStatus = 'STARTED') {
 
 def update_build_status(summary) {
   def job_base_url = "https://jenkins-me.v2v.bos.redhat.com/blue/organizations/jenkins/mig-controller-pr-builder-base/detail/mig-controller-pr-builder-base/${BUILD_NUMBER}/pipeline"
-  summary = "@${ghprbActualCommitAuthor}\n" + summary + "\nFind full log [here](${job_base_url})"
+  summary = summary + "\nFind full log [here](${job_base_url})"
   sh "echo ${summary} >> ${JENKINS_HOME}/jobs/${JOB_NAME}/builds/${BUILD_NUMBER}/summary"
 }
 

--- a/pipeline/utils.groovy
+++ b/pipeline/utils.groovy
@@ -36,14 +36,14 @@ def notifyBuild(String buildStatus = 'STARTED') {
   update_build_status(body)
 
   // Send notifications
-  // slackSend (color: colorCode, message: message)
+  slackSend (color: colorCode, message: message)
 }
 
 def update_build_status(body) {
   // def mention = PR_AUTHOR ? "${PR_AUTHOR}\n" : ""
   comment = body +
     "\nFind full build log [here](https://jenkins-me.v2v.bos.redhat.com/blue/organizations/jenkins/${env.JOB_NAME}/detail/${env.JOB_NAME}/${env.BUILD_NUMBER}/pipeline)" +
-    "\nFind instructions to debug [here](https://gist.github.com/pranavgaikwad/bfef347f870159f6abac3dabe495fe16)"
+    "\nFind instructions to debug [here](https://github.com/konveyor/mig-ci/blob/master/DEBUG-GUIDE.md)"
   sh "echo '${comment}' > ${JENKINS_HOME}/jobs/${JOB_NAME}/builds/${BUILD_NUMBER}/summary"
 }
 

--- a/pipeline/utils.groovy
+++ b/pipeline/utils.groovy
@@ -40,8 +40,8 @@ def notifyBuild(String buildStatus = 'STARTED') {
 }
 
 def update_build_status(body) {
-  def mention = PR_AUTHOR ? "${PR_AUTHOR}\n" : ""
-  comment = mention + body + "\nFind full log [here](${env.BUILD_URL})"
+  // def mention = PR_AUTHOR ? "${PR_AUTHOR}\n" : ""
+  comment = body + "\nFind full log [here](${env.BUILD_URL})"
   sh "echo '${comment}' >> ${JENKINS_HOME}/jobs/${JOB_NAME}/builds/${BUILD_NUMBER}/summary"
 }
 

--- a/pipeline/utils.groovy
+++ b/pipeline/utils.groovy
@@ -41,8 +41,10 @@ def notifyBuild(String buildStatus = 'STARTED') {
 
 def update_build_status(body) {
   // def mention = PR_AUTHOR ? "${PR_AUTHOR}\n" : ""
-  comment = body + "\nFind full log [here](https://jenkins-me.v2v.bos.redhat.com/blue/organizations/jenkins/${env.JOB_NAME}/detail/${env.JOB_NAME}/${env.BUILD_NUMBER}/pipeline)"
-  sh "echo '${comment}' >> ${JENKINS_HOME}/jobs/${JOB_NAME}/builds/${BUILD_NUMBER}/summary"
+  comment = body + 
+    "\nFind complete debug info [here](https://jenkins-me.v2v.bos.redhat.com/blue/rest/organizations/jenkins/pipelines/${env.JOB_NAME}/runs/${env.BUILD_NUMBER}/nodes/201/steps/236/log/?start=0)" +
+    "\nFind full build log [here](https://jenkins-me.v2v.bos.redhat.com/blue/organizations/jenkins/${env.JOB_NAME}/detail/${env.JOB_NAME}/${env.BUILD_NUMBER}/pipeline)"
+  sh "echo '${comment}' > ${JENKINS_HOME}/jobs/${JOB_NAME}/builds/${BUILD_NUMBER}/summary"
 }
 
 def clone_mig_e2e() {

--- a/pipeline/utils.groovy
+++ b/pipeline/utils.groovy
@@ -8,6 +8,8 @@ def notifyBuild(String buildStatus = 'STARTED') {
   def colorCode = '#FF0000'
   def subject = "${buildStatus}: Job '${env.JOB_NAME}, build [${env.BUILD_NUMBER}]'"
   def summary = "${subject}\nLink: (${env.BUILD_URL})\n"
+  def body = ""
+  def message = "${summary}${body}"
   def results = []
 
   for (i = 0; i < steps_finished.size() - 1; i++) {
@@ -21,26 +23,26 @@ def notifyBuild(String buildStatus = 'STARTED') {
     colorCode = '#00FF00'
     results.add(':heavy_check_mark:')
     steps_finished.eachWithIndex { step, id ->
-      summary = summary + results[id] + '\t' + step + '\n'
+      body = body + results[id] + '\t' + step + '\n'
     }
   } else {
     colorCode = '#FF0000'
     results.add(':x:')
     steps_finished.eachWithIndex { step, id ->
-      summary = summary + results[id] + '\t' + step + '\n'
+      body = body + results[id] + '\t' + step + '\n'
     }
   }
 
-  update_build_status(summary)
+  update_build_status(body)
 
   // Send notifications
-  // slackSend (color: colorCode, message: summary)
+  // slackSend (color: colorCode, message: message)
 }
 
-def update_build_status(summary) {
-  def job_base_url = "https://jenkins-me.v2v.bos.redhat.com/blue/organizations/jenkins/mig-controller-pr-builder-base/detail/mig-controller-pr-builder-base/${BUILD_NUMBER}/pipeline"
-  summary = summary + "\nFind full log [here](${job_base_url})"
-  sh "echo '${summary}' >> ${JENKINS_HOME}/jobs/${JOB_NAME}/builds/${BUILD_NUMBER}/summary"
+def update_build_status(body) {
+  def mention = PR_AUTHOR != null ? "${PR_AUTHOR}\n" : ""
+  comment = mention + body + "\nFind full log [here](${${env.BUILD_URL}})"
+  sh "echo '${comment}' >> ${JENKINS_HOME}/jobs/${JOB_NAME}/builds/${BUILD_NUMBER}/summary"
 }
 
 def clone_mig_e2e() {

--- a/pipeline/utils.groovy
+++ b/pipeline/utils.groovy
@@ -40,7 +40,7 @@ def notifyBuild(String buildStatus = 'STARTED') {
 }
 
 def update_build_status(body) {
-  def mention = PR_AUTHOR != null ? "${PR_AUTHOR}\n" : ""
+  def mention = PR_AUTHOR ? "${PR_AUTHOR}\n" : ""
   comment = mention + body + "\nFind full log [here](${${env.BUILD_URL}})"
   sh "echo '${comment}' >> ${JENKINS_HOME}/jobs/${JOB_NAME}/builds/${BUILD_NUMBER}/summary"
 }

--- a/pipeline/utils.groovy
+++ b/pipeline/utils.groovy
@@ -43,7 +43,7 @@ def update_build_status(body) {
   // def mention = PR_AUTHOR ? "${PR_AUTHOR}\n" : ""
   comment = body +
     "\nFind full build log [here](https://jenkins-me.v2v.bos.redhat.com/blue/organizations/jenkins/${env.JOB_NAME}/detail/${env.JOB_NAME}/${env.BUILD_NUMBER}/pipeline)" +
-    "\nFind the build step titled 'Gather debug info...' in above log for complete debug information of the build environment"
+    "\nFind instructions to debug [here](https://gist.github.com/pranavgaikwad/bfef347f870159f6abac3dabe495fe16)"
   sh "echo '${comment}' > ${JENKINS_HOME}/jobs/${JOB_NAME}/builds/${BUILD_NUMBER}/summary"
 }
 

--- a/pipeline/utils.groovy
+++ b/pipeline/utils.groovy
@@ -43,7 +43,7 @@ def update_build_status(body) {
   // def mention = PR_AUTHOR ? "${PR_AUTHOR}\n" : ""
   comment = body +
     "\nFind full build log [here](https://jenkins-me.v2v.bos.redhat.com/blue/organizations/jenkins/${env.JOB_NAME}/detail/${env.JOB_NAME}/${env.BUILD_NUMBER}/pipeline)" +
-    "\nFind the step titled 'Debug' in above log for complete debug information of the build environment"
+    "\nFind the build step titled 'Gather debug info...' in above log for complete debug information of the build environment"
   sh "echo '${comment}' > ${JENKINS_HOME}/jobs/${JOB_NAME}/builds/${BUILD_NUMBER}/summary"
 }
 

--- a/pipeline/utils.groovy
+++ b/pipeline/utils.groovy
@@ -41,7 +41,7 @@ def notifyBuild(String buildStatus = 'STARTED') {
 
 def update_build_status(body) {
   // def mention = PR_AUTHOR ? "${PR_AUTHOR}\n" : ""
-  comment = body + "\nFind full log [here](${env.JENKINS_URL}/blue/organizations/jenkins/${env.JOB_NAME}/detail/${env.JOB_NAME}/${env.BUILD_NUMBER}/pipeline)"
+  comment = body + "\nFind full log [here](https://jenkins-me.v2v.bos.redhat.com/blue/organizations/jenkins/${env.JOB_NAME}/detail/${env.JOB_NAME}/${env.BUILD_NUMBER}/pipeline)"
   sh "echo '${comment}' >> ${JENKINS_HOME}/jobs/${JOB_NAME}/builds/${BUILD_NUMBER}/summary"
 }
 

--- a/pipeline/utils.groovy
+++ b/pipeline/utils.groovy
@@ -41,7 +41,7 @@ def notifyBuild(String buildStatus = 'STARTED') {
 
 def update_build_status(body) {
   // def mention = PR_AUTHOR ? "${PR_AUTHOR}\n" : ""
-  comment = body + "\nFind full log [here](${env.BUILD_URL})"
+  comment = body + "\nFind full log [here](${env.JENKINS_URL}/blue/organizations/jenkins/${env.JOB_NAME}/detail/${env.JOB_NAME}/${env.BUILD_NUMBER}/pipeline)"
   sh "echo '${comment}' >> ${JENKINS_HOME}/jobs/${JOB_NAME}/builds/${BUILD_NUMBER}/summary"
 }
 

--- a/pipeline/utils.groovy
+++ b/pipeline/utils.groovy
@@ -40,7 +40,7 @@ def notifyBuild(String buildStatus = 'STARTED') {
 def update_build_status(summary) {
   def job_base_url = "https://jenkins-me.v2v.bos.redhat.com/blue/organizations/jenkins/mig-controller-pr-builder-base/detail/mig-controller-pr-builder-base/${BUILD_NUMBER}/pipeline"
   summary = summary + "\nFind full log [here](${job_base_url})"
-  sh "echo ${summary} >> ${JENKINS_HOME}/jobs/${JOB_NAME}/builds/${BUILD_NUMBER}/summary"
+  sh "echo '${summary}' >> ${JENKINS_HOME}/jobs/${JOB_NAME}/builds/${BUILD_NUMBER}/summary"
 }
 
 def clone_mig_e2e() {

--- a/pipeline/utils.groovy
+++ b/pipeline/utils.groovy
@@ -41,9 +41,9 @@ def notifyBuild(String buildStatus = 'STARTED') {
 
 def update_build_status(body) {
   // def mention = PR_AUTHOR ? "${PR_AUTHOR}\n" : ""
-  comment = body + 
-    "\nFind complete debug info [here](https://jenkins-me.v2v.bos.redhat.com/blue/rest/organizations/jenkins/pipelines/${env.JOB_NAME}/runs/${env.BUILD_NUMBER}/nodes/201/steps/236/log/?start=0)" +
-    "\nFind full build log [here](https://jenkins-me.v2v.bos.redhat.com/blue/organizations/jenkins/${env.JOB_NAME}/detail/${env.JOB_NAME}/${env.BUILD_NUMBER}/pipeline)"
+  comment = body +
+    "\nFind full build log [here](https://jenkins-me.v2v.bos.redhat.com/blue/organizations/jenkins/${env.JOB_NAME}/detail/${env.JOB_NAME}/${env.BUILD_NUMBER}/pipeline)" +
+    "\nFind the step titled 'Debug' in above log for complete debug information of the build environment"
   sh "echo '${comment}' > ${JENKINS_HOME}/jobs/${JOB_NAME}/builds/${BUILD_NUMBER}/summary"
 }
 
@@ -319,9 +319,9 @@ def teardown_e2e_purge_pv(kubeconfig) {
   }
 }
 
-def run_debug(kubeconfig) {
+def run_debug(kubeconfig, title) {
   withEnv([ "KUBECONFIG=${kubeconfig}" ]) {
-    sh "${DEBUG_SCRIPT} ${DEBUG_SCRIPT_ARGS} || true"
+    sh script: "${DEBUG_SCRIPT} ${DEBUG_SCRIPT_ARGS} || true", label: "Debug ${title}"
   }
 }
 

--- a/pipeline/utils.groovy
+++ b/pipeline/utils.groovy
@@ -1,5 +1,4 @@
 // utils.groovy
-
 def notifyBuild(String buildStatus = 'STARTED') {
   // build status of null means successful
   buildStatus =  buildStatus ?: 'SUCCESSFUL'
@@ -32,8 +31,16 @@ def notifyBuild(String buildStatus = 'STARTED') {
     }
   }
 
+  update_build_status(summary)
+
   // Send notifications
   // slackSend (color: colorCode, message: summary)
+}
+
+def update_build_status(summary) {
+  def job_base_url = "https://jenkins-me.v2v.bos.redhat.com/blue/organizations/jenkins/mig-controller-pr-builder-base/detail/mig-controller-pr-builder-base/${BUILD_NUMBER}/pipeline"
+  summary = "@${ghprbActualCommitAuthor}\n" + summary + "\nFind full log [here](${job_base_url})"
+  sh "echo ${summary} >> ${JENKINS_HOME}/jobs/${JOB_NAME}/builds/${BUILD_NUMBER}/summary"
 }
 
 def clone_mig_e2e() {

--- a/pipeline/utils.groovy
+++ b/pipeline/utils.groovy
@@ -41,7 +41,7 @@ def notifyBuild(String buildStatus = 'STARTED') {
 
 def update_build_status(body) {
   def mention = PR_AUTHOR ? "${PR_AUTHOR}\n" : ""
-  comment = mention + body + "\nFind full log [here](${${env.BUILD_URL}})"
+  comment = mention + body + "\nFind full log [here](${env.BUILD_URL})"
   sh "echo '${comment}' >> ${JENKINS_HOME}/jobs/${JOB_NAME}/builds/${BUILD_NUMBER}/summary"
 }
 


### PR DESCRIPTION
Refactors mig_controller_deploy_on_both() function to accept only one cluster info

Breaks down mig-controller and mig-operator deployment steps

