### PR TITLE
Fix OLM and non-olm issues using latest

### DIFF
--- a/roles/mig_controller_prereqs/tasks/operator_upstream_non_olm.yml
+++ b/roles/mig_controller_prereqs/tasks/operator_upstream_non_olm.yml
@@ -4,7 +4,7 @@
 
     - name: "Fetch available non-olm konveyor releases"
       find: 
-        path: "{{ playbook_dir }}/mig-operator/deploy/non-olm" 
+        path: "{{ mig_operator_location }}/deploy/non-olm" 
         patterns: "v*" 
         file_type: "directory"
       register: releases

--- a/roles/mig_controller_prereqs/tasks/operator_upstream_non_olm.yml
+++ b/roles/mig_controller_prereqs/tasks/operator_upstream_non_olm.yml
@@ -1,5 +1,26 @@
 ---
+- name: "Obtain latest konveyor release"
+  block:
+
+    - name: "Fetch available non-olm konveyor releases"
+      find: 
+        path: "{{ playbook_dir }}/mig-operator/deploy/non-olm" 
+        patterns: "v*" 
+        file_type: "directory"
+      register: releases
+
+    - name: "Extract latest konveyor release path"
+      set_fact:
+        konveyor_latest_dir: "{{ releases.files | sort(attribute='path') | map(attribute='path') | list | last }}"
+
+    - name: "Deploy non-olm mig upstream latest operator"
+      k8s:
+        state : present
+        definition: "{{ lookup('file', '{{ konveyor_latest_dir }}/operator.yml' )}}"
+  when: mig_operator_release == 'latest'
+
 - name: "Deploy non-olm mig upstream operator"
   k8s:
     state : present
     definition: "{{ lookup('file', '{{ mig_operator_location }}/deploy/non-olm/{{ mig_operator_release }}/operator.yml' )}}"
+  when: mig_operator_release != 'latest'

--- a/roles/mig_controller_prereqs/tasks/operator_upstream_olm.yml
+++ b/roles/mig_controller_prereqs/tasks/operator_upstream_olm.yml
@@ -3,7 +3,7 @@
 
     - name: "Load konveyor operator package file"
       set_fact:
-        konveyor_pkg_file: "{{ lookup('file', '{{ playbook_dir }}/mig-operator/deploy/olm-catalog/konveyor-operator/konveyor-operator.package.yaml') | from_yaml }}"
+        konveyor_pkg_file: "{{ lookup('file', '{{ mig_operator_location }}/deploy/olm-catalog/konveyor-operator/konveyor-operator.package.yaml') | from_yaml }}"
 
     - name: "Extract latest konveyor channel"
       set_fact:

--- a/roles/mig_controller_prereqs/tasks/operator_upstream_olm.yml
+++ b/roles/mig_controller_prereqs/tasks/operator_upstream_olm.yml
@@ -1,3 +1,16 @@
+- name: "Obtain latest konveyor channel"
+  block:
+
+    - name: "Load konveyor operator package file"
+      set_fact:
+        konveyor_pkg_file: "{{ lookup('file', '{{ playbook_dir }}/mig-operator/deploy/olm-catalog/konveyor-operator/konveyor-operator.package.yaml') | from_yaml }}"
+
+    - name: "Extract latest konveyor channel"
+      set_fact:
+        konveyor_latest_channel: "{{ konveyor_pkg_file.channels | sort(attribute='name') | map(attribute='name') | list | last }}"
+
+  when: mig_operator_release == 'latest'
+
 - name: "Deploy upstream mig operator using OLM"
   block:
 

--- a/roles/mig_controller_prereqs/templates/mig-operator-subscription.yml.j2
+++ b/roles/mig_controller_prereqs/templates/mig-operator-subscription.yml.j2
@@ -8,8 +8,8 @@ metadata:
 {% endif %}
   namespace: {{ mig_migration_namespace }}
 spec:
-{% if mig_operator_release == 'latest' %}
-  channel: latest
+{% if konveyor_latest_channel is defined and mig_operator_release == 'latest' %}
+  channel: {{ konveyor_latest_channel }}
 {% elif mig_operator_release == 'v1.0' %}
   channel: release-v1
 {% else %}


### PR DESCRIPTION
- OLM channel latest is deprecated and also latest symlinks are gone
  from mig-operator repo
- Allow Jenkins CI to use latest internally and provide ansible logic to obtain latest
  releases and directories from mig-operator repo
- Only affects konveyor builds on latest and PR building