### PR TITLE
Deploy UI only on host cluster

### DIFF
--- a/pipeline/common_stages.groovy
+++ b/pipeline/common_stages.groovy
@@ -426,7 +426,7 @@ def deploy_mig_controller(kubeconfig, is_host, cluster_version) {
 
       def mig_controller_deployment_args = is_host ?
         "-e mig_controller_host_cluster='true' -e mig_controller_ui=${MIG_CONTROLLER_UI}" : 
-        "-e mig_controller_host_cluster='false' -e mig_controller_ui=${MIG_CONTROLLER_UI}"
+        "-e mig_controller_host_cluster='false'"
 
       withCredentials([
         string(credentialsId: "$EC2_SUB_USER", variable: 'SUB_USER'),

--- a/pipeline/mig-controller-pr-builder.groovy
+++ b/pipeline/mig-controller-pr-builder.groovy
@@ -28,7 +28,7 @@ credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.Usernam
 credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl', defaultValue: 'ci_rhel_sub_user', description: 'RHEL Openshift subscription account username', name: 'EC2_SUB_USER', required: true),
 credentials(credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl', defaultValue: 'ci_rhel_sub_pass', description: 'RHEL Openshift subscription account password', name: 'EC2_SUB_PASS', required: true),
 booleanParam(defaultValue: false, description: 'Deploy e2e applications and prepare clusters only, do not migrate', name: 'E2E_DEPLOY_ONLY'),
-booleanParam(defaultValue: true, description: 'Deploy mig controller UI on destination cluster', name: 'MIG_CONTROLLER_UI'),
+booleanParam(defaultValue: true, description: 'Deploy controller UI on host cluster', name: 'MIG_CONTROLLER_UI'),
 booleanParam(defaultValue: true, description: 'Deploy mig operator using OLM on OCP4', name: 'USE_OLM'),
 booleanParam(defaultValue: false, description: 'Deploy using downstream images', name: 'USE_DOWNSTREAM'),
 booleanParam(defaultValue: true, description: 'Enable debugging', name: 'DEBUG'),

--- a/pipeline/mig-e2e-base.groovy
+++ b/pipeline/mig-e2e-base.groovy
@@ -28,7 +28,7 @@ booleanParam(defaultValue: false, description: 'Deploy e2e applications and prep
 booleanParam(defaultValue: true, description: 'Deploy mig operator using OLM on OCP4', name: 'USE_OLM'),
 booleanParam(defaultValue: false, description: 'Deploy using downstream images', name: 'USE_DOWNSTREAM'),
 booleanParam(defaultValue: false, description: 'Deploy CAM disconnected, not used on non-deployment pipelines', name: 'USE_DISCONNECTED'),
-booleanParam(defaultValue: true, description: 'Deploy mig controller UI on destination cluster', name: 'MIG_CONTROLLER_UI'),
+booleanParam(defaultValue: true, description: 'Deploy controller UI on host cluster', name: 'MIG_CONTROLLER_UI'),
 booleanParam(defaultValue: false, description: 'Enable debugging', name: 'DEBUG'),
 booleanParam(defaultValue: true, description: 'Clean up workspace after build', name: 'CLEAN_WORKSPACE')])])
 

--- a/pipeline/parallel-base.groovy
+++ b/pipeline/parallel-base.groovy
@@ -60,7 +60,7 @@ booleanParam(defaultValue: true, description: 'Clean up workspace after build', 
 booleanParam(defaultValue: false, description: 'Persistent cluster builds with fixed hostname', name: 'PERSISTENT'),
 booleanParam(defaultValue: false, description: 'Enable debugging', name: 'DEBUG'),
 booleanParam(defaultValue: true, description: 'EC2 terminate instances after build', name: 'EC2_TERMINATE_INSTANCES'),
-booleanParam(defaultValue: true, description: 'Deploy mig controller UI on destination cluster', name: 'MIG_CONTROLLER_UI')])])
+booleanParam(defaultValue: true, description: 'Deploy controller UI on host cluster', name: 'MIG_CONTROLLER_UI')])])
 
 // true/false build parameter that defines if CAM is deployed
 def DEPLOY_CAM = params.DEPLOY_CAM

--- a/roles/mig_controller_prereqs/defaults/main.yml
+++ b/roles/mig_controller_prereqs/defaults/main.yml
@@ -12,7 +12,7 @@ mig_controller_repo: "{{ lookup('env', 'MIG_CONTROLLER_REPO') or 'https://github
 mig_controller_branch: "{{ lookup('env', 'MIG_CONTROLLER_BRANCH') or 'master' }}"
 mig_controller_host_cluster: true
 mig_controller_velero: true
-mig_controller_ui: true
+mig_controller_ui: false
 mig_controller_remote_cluster_online: true
 mig_migration_namespace: openshift-migration
 rh_sub_user: "{{ lookup('env', 'SUB_USER') }}"


### PR DESCRIPTION
- Set UI deployment on ansible roles to false by default
- Ensure deployment of UI only on host cluster, MIG_CONTROLLER_UI must
  also be set to true on parameters (default)