### PR TITLE
Re introduce lastest channel and operator symlink

### DIFF
--- a/roles/mig_controller_prereqs/tasks/operator_upstream_non_olm.yml
+++ b/roles/mig_controller_prereqs/tasks/operator_upstream_non_olm.yml
@@ -1,26 +1,5 @@
 ---
-- name: "Obtain latest konveyor release"
-  block:
-
-    - name: "Fetch available non-olm konveyor releases"
-      find: 
-        path: "{{ mig_operator_location }}/deploy/non-olm" 
-        patterns: "v*" 
-        file_type: "directory"
-      register: releases
-
-    - name: "Extract latest konveyor release path"
-      set_fact:
-        konveyor_latest_dir: "{{ releases.files | sort(attribute='path') | map(attribute='path') | list | last }}"
-
-    - name: "Deploy non-olm mig upstream latest operator"
-      k8s:
-        state : present
-        definition: "{{ lookup('file', '{{ konveyor_latest_dir }}/operator.yml' )}}"
-  when: mig_operator_release == 'latest'
-
 - name: "Deploy non-olm mig upstream operator"
   k8s:
     state : present
     definition: "{{ lookup('file', '{{ mig_operator_location }}/deploy/non-olm/{{ mig_operator_release }}/operator.yml' )}}"
-  when: mig_operator_release != 'latest'

--- a/roles/mig_controller_prereqs/tasks/operator_upstream_olm.yml
+++ b/roles/mig_controller_prereqs/tasks/operator_upstream_olm.yml
@@ -1,16 +1,3 @@
-- name: "Obtain latest konveyor channel"
-  block:
-
-    - name: "Load konveyor operator package file"
-      set_fact:
-        konveyor_pkg_file: "{{ lookup('file', '{{ mig_operator_location }}/deploy/olm-catalog/konveyor-operator/konveyor-operator.package.yaml') | from_yaml }}"
-
-    - name: "Extract latest konveyor channel"
-      set_fact:
-        konveyor_latest_channel: "{{ konveyor_pkg_file.channels | sort(attribute='name') | map(attribute='name') | list | last }}"
-
-  when: mig_operator_release == 'latest'
-
 - name: "Deploy upstream mig operator using OLM"
   block:
 

--- a/roles/mig_controller_prereqs/templates/mig-operator-subscription.yml.j2
+++ b/roles/mig_controller_prereqs/templates/mig-operator-subscription.yml.j2
@@ -8,7 +8,11 @@ metadata:
 {% endif %}
   namespace: {{ mig_migration_namespace }}
 spec:
+{% if mig_operator_release == 'latest' %}
+  channel: latest
+{% else %}
   channel: release-{{ mig_operator_release }}
+{% endif %}
   installPlanApproval: Automatic
 {% if mig_operator_use_downstream|bool is sameas true %}
   name: cam-operator

--- a/roles/mig_controller_prereqs/templates/mig-operator-subscription.yml.j2
+++ b/roles/mig_controller_prereqs/templates/mig-operator-subscription.yml.j2
@@ -9,7 +9,6 @@ metadata:
   namespace: {{ mig_migration_namespace }}
 spec:
   channel: release-{{ mig_operator_release }}
-{% endif %}
   installPlanApproval: Automatic
 {% if mig_operator_use_downstream|bool is sameas true %}
   name: cam-operator

--- a/roles/mig_controller_prereqs/templates/mig-operator-subscription.yml.j2
+++ b/roles/mig_controller_prereqs/templates/mig-operator-subscription.yml.j2
@@ -8,11 +8,6 @@ metadata:
 {% endif %}
   namespace: {{ mig_migration_namespace }}
 spec:
-{% if konveyor_latest_channel is defined and mig_operator_release == 'latest' %}
-  channel: {{ konveyor_latest_channel }}
-{% elif mig_operator_release == 'v1.0' %}
-  channel: release-v1
-{% else %}
   channel: release-{{ mig_operator_release }}
 {% endif %}
   installPlanApproval: Automatic


### PR DESCRIPTION
This PR relies on the existence of the latest channel and also appropiate symlinks on non-olm mig-operator deployments. Those are "latest" , "v1.1", "v1.2" etc.

* Remove unnecessary logic needed to deal with the absence of a latest channel on OLM and missing non-olm (ocp3) latest directory/symlink
* mig_operator_release controls CAM/MTC version being tested
* Remove fixes for deprecated v1.0