### PR TITLE
CI cleanups and minor fixes

### DIFF
--- a/pipeline/common_stages.groovy
+++ b/pipeline/common_stages.groovy
@@ -62,13 +62,6 @@ def deploy_ocp4_agnosticd(kubeconfig, cluster_version) {
     stage('Deploy agnosticd OCP workshop ' + cluster_version + OLM_TEXT) {
       steps_finished << 'Deploy agnosticd OCP workshop ' + cluster_version + OLM_TEXT
 
-        dir("olm") {
-          def olm_vars = [
-            'olm_cluster_version': "${cluster_version}"
-          ]
-          writeYaml file: 'olm_vars.yml', data: olm_vars
-        }
-
         dir("mig-agnosticd/${cluster_version}") {
           def my_vars = [
             'email': "${EMAIL}",
@@ -276,7 +269,7 @@ def deploy_workload(workload,cluster_version,status) {
   }
   return {
     if (status == 'true') {
-      stage('Deploy ${workload} workload on ' + cluster_version) {
+      stage("Deploy ${workload} workload on ${cluster_version}") {
         steps_finished << 'Deploy ${workload} workload on ' + cluster_version
         sh 'sleep 180'
         dir("mig-agnosticd/workloads") {

--- a/roles/get_ocp_version/tasks/main.yml
+++ b/roles/get_ocp_version/tasks/main.yml
@@ -13,7 +13,8 @@
       '3.11' if k8s_minor_version is version('11', '=') else
       '4.1' if k8s_minor_version is version('13', '=') else
       '4.2' if k8s_minor_version is version('14', '=') else
-      '4.3' if k8s_minor_version is version('16', '>=') }}"
+      '4.3' if k8s_minor_version is version('16', '=') else
+      '4.4' if k8s_minor_version is version('17', '>=') }}"
 
 - set_fact:
     cluster_version: "{{ cluster_version|replace('\"', '') }}"

--- a/roles/login_ocp/tasks/download_oc_binary.yml
+++ b/roles/login_ocp/tasks/download_oc_binary.yml
@@ -1,10 +1,10 @@
-- name: Check that oc binary is installed
+- name: "Check that oc binary is installed"
   stat:
     path: "{{ oc_binary }}"
   register: oc_installed
 
 - block:
-  - name: Fetch page content for latest client binary archive 
+  - name: "Fetch page content for latest client binary archive"
     uri: 
       url: "{{ release_url }}"
       return_content: yes
@@ -13,7 +13,7 @@
     retries: 12
     delay: 10
 
-  - name: Determine latest client binary archive release
+  - name: "Determine latest client binary archive release"
     set_fact:
       release_ver: "{{ client_page.content | regex_findall('<a.*openshift-client-linux[^<]+?>') | first | regex_search('o.*\\d[-.0-9]+\\d') }}"
 
@@ -22,7 +22,7 @@
       oc_release_url: "{{ release_url }}/{{ release_ver }}.tar.gz"
       oc_arch: "{{ oc_target_location }}/{{ release_ver }}/client.tar.gz"
     
-  - name: Create binary directory
+  - name: "Create binary directory"
     file:
         path: "{{ item }}"
         recurse: true
@@ -31,7 +31,7 @@
       - "{{ oc_target_location }}"
       - "{{ oc_arch | dirname }}"
 
-  - name: Get client binary archive
+  - name: "Get client binary archive"
     get_url:
       url: "{{ oc_release_url }}"
       dest: "{{ oc_arch }}"
@@ -46,12 +46,18 @@
       dest: "{{ oc_arch | dirname }}"
       remote_src: yes
 
-  - name: Install newly downloaded oc binary
+  - name: "Install newly downloaded oc binary"
     copy:
       src: "{{ oc_arch | dirname }}/oc"
       dest: "{{ oc_binary }}"
       mode: 0755
       remote_src: True
+
+  - name: "Remove oc binary archive directory"
+    file:
+      path: "{{ oc_arch | dirname }}"
+      state: absent
+
   when: not oc_installed.stat.exists
 
 - name: Ensure source kubeconfig dir was created

--- a/roles/mig_controller_deploy/defaults/olm_vars.yml
+++ b/roles/mig_controller_deploy/defaults/olm_vars.yml
@@ -1,2 +1,0 @@
----
-olm_cluster_version: '4.2'

--- a/roles/mig_controller_deploy/tasks/deploy.yml
+++ b/roles/mig_controller_deploy/tasks/deploy.yml
@@ -1,20 +1,5 @@
 - debug:
     msg: "Mig controller will deploy using release: {{ mig_operator_release }}"
-
-- name: Deploying mig controller using OLM
-  block:
-
-    - name: Include required vars
-      include_vars:  "{{ lookup('first_found', olm_files) }}"
-      vars:
-        olm_files:
-          - "{{ playbook_dir }}/olm/olm_vars.yml"
-          - "{{ playbook_dir }}/roles/mig_controller_deploy/defaults/olm_vars.yml"
-    
-    - debug:
-        msg: "OLM cluster version: {{ olm_cluster_version }}"
-
-  when: mig_operator_use_olm|bool
     
 - name: Deploy mig controller
   k8s:

--- a/roles/mig_controller_deploy/tasks/main.yml
+++ b/roles/mig_controller_deploy/tasks/main.yml
@@ -7,6 +7,11 @@
     - "{{ playbook_dir }}/roles/mig_controller_prereqs/defaults/main.yml"
     - "{{ playbook_dir }}/config/velero_aws_creds.yml"
 
+- include_role:
+    name: get_ocp_version
+  vars:
+    - show_cluster_api: true
+
 - name: Deploy mig controller
   import_tasks: deploy.yml
 

--- a/roles/mig_controller_deploy/templates/controller.yml.j2
+++ b/roles/mig_controller_deploy/templates/controller.yml.j2
@@ -22,10 +22,8 @@ spec:
   mig_controller_version: {{ mig_controller_version }}
 {% endif %}
 {% endif %}
-{% if olm_cluster_version is defined %}
-{% if '4.1' in olm_cluster_version|string %}
+{% if cluster_version == '4.1' %}
   deprecated_cors_configuration: true
-{% endif %}
 {% endif %}
   #To install the controller on Openshift 3 you will need to configure the API endpoint:
   #mig_ui_cluster_api_endpoint: https://replace-with-openshift-cluster-hostname:8443

--- a/roles/mig_controller_prereqs/tasks/main.yml
+++ b/roles/mig_controller_prereqs/tasks/main.yml
@@ -3,5 +3,10 @@
 - name: Create AWS backup storage
   import_tasks: create_aws_backup_storage.yml
 
+- include_role:
+    name: get_ocp_version
+  vars:
+    - show_cluster_api: true
+
 - name: Deploy mig operator
   import_tasks: deploy_operator.yml

--- a/roles/mig_controller_prereqs/tasks/operator_downstream_olm.yml
+++ b/roles/mig_controller_prereqs/tasks/operator_downstream_olm.yml
@@ -1,17 +1,6 @@
 - name: "Deploy downstream mig operator using OLM"
   block:
 
-    - name: "Include required vars"
-      include_vars:  "{{ lookup('first_found', olm_files) }}"
-      vars:
-        olm_files:
-          - "{{ playbook_dir }}/olm/olm_vars.yml"
-          - "{{ playbook_dir }}/roles/mig_controller_deploy/defaults/olm_vars.yml"
-
-    - debug:
-        msg:
-          - "OLM cluster version: {{ olm_cluster_version }}"
-
     - name: "Create {{ mig_migration_namespace }} namespace"
       k8s:
         name: "{{ mig_migration_namespace }}"

--- a/roles/mig_controller_prereqs/tasks/operator_upstream_olm.yml
+++ b/roles/mig_controller_prereqs/tasks/operator_upstream_olm.yml
@@ -1,17 +1,6 @@
 - name: "Deploy upstream mig operator using OLM"
   block:
 
-    - name: "Include required vars"
-      include_vars:  "{{ lookup('first_found', olm_files) }}"
-      vars:
-        olm_files:
-          - "{{ playbook_dir }}/olm/olm_vars.yml"
-          - "{{ playbook_dir }}/roles/mig_controller_deploy/defaults/olm_vars.yml"
-
-    - debug:
-        msg:
-          - "OLM cluster version: {{ olm_cluster_version }}"
-
     - name: "Create OperatorSource"
       k8s:
         state: present
@@ -24,7 +13,7 @@
     - name: "Define OperatorSource pod label"
       set_fact:
         mig_operator_label: "marketplace.catalogSourceConfig=migration-operator"
-      when: olm_cluster_version is version('4.1', '<=')
+      when: cluster_version is version('4.1', '<=')
 
     - name: "Define OperatorSource pod label"
       set_fact:
@@ -32,7 +21,7 @@
           'marketplace.operatorSource=konveyor-ci-operators' if mig_operator_build_custom|bool 
           else 'marketplace.operatorSource=migration-operator' 
         }}"
-      when: not olm_cluster_version is version('4.1', '<=')
+      when: not cluster_version is version('4.1', '<=')
 
     - name: "Wait for OLM to reconcile OperatorSource creation"
       k8s_facts:


### PR DESCRIPTION
- Remove olm_vars file and olm_cluster_version variables, replaced by ocp_get_version role
- Add/Update entry for OCP 4.4GA to get_ocp_version role
- Minor print fix to deploy_workload function in common_methods
- Add oc client tarball directory cleanup on login_ocp role, reduces disk space consumed on Jenkins server