### PR TITLE
Introduce OCP 4.5 pre-release to pipelines

### DIFF
--- a/pipeline/common_stages.groovy
+++ b/pipeline/common_stages.groovy
@@ -264,7 +264,7 @@ def deploy_ocp3_agnosticd(kubeconfig, cluster_version) {
 
 def deploy_workload(workload,cluster_version,status) {
   def short_version = cluster_version.tokenize(".")[0]
-  if (cluster_version == "nightly") {
+  if (!cluster_version.startsWith("3.")) {
     short_version = '4'
   }
   return {

--- a/pipeline/mig-controller-pr-builder.groovy
+++ b/pipeline/mig-controller-pr-builder.groovy
@@ -1,7 +1,7 @@
 // mig-e2e-base.groovy
 properties([
-parameters([choice(choices: ['3.7', '3.9', '3.10', '3.11', '4.1', '4.2', '4.3', '4.4', 'nightly'], description: 'Source cluster version to test', name: 'SRC_CLUSTER_VERSION'),
-choice(choices: ['4.3', '3.11', '3.10', '3.9', '3.7', '4.1', '4.2', '4.4', 'nightly'], description: 'Destination cluster version to test', name: 'DEST_CLUSTER_VERSION'),
+parameters([choice(choices: ['3.7', '3.9', '3.10', '3.11', '4.1', '4.2', '4.3', '4.4', 'pre-4.5', 'nightly'], description: 'Source cluster version to test', name: 'SRC_CLUSTER_VERSION'),
+choice(choices: ['4.3', '3.11', '3.10', '3.9', '3.7', '4.1', '4.2', '4.4', 'pre-4.5', 'nightly'], description: 'Destination cluster version to test', name: 'DEST_CLUSTER_VERSION'),
 string(defaultValue: '', description: 'Source cluster API endpoint', name: 'SRC_CLUSTER_URL', trim: false),
 string(defaultValue: '', description: 'Destination cluster API endpoint', name: 'DEST_CLUSTER_URL', trim: false),
 string(defaultValue: '', description: 'AWS region where clusters are deployed', name: 'AWS_REGION', trim: false),

--- a/pipeline/mig-e2e-base.groovy
+++ b/pipeline/mig-e2e-base.groovy
@@ -1,7 +1,7 @@
 // mig-e2e-base.groovy
 properties([
-parameters([choice(choices: ['3.7', '3.9', '3.10', '3.11', '4.1', '4.2', '4.3', '4.4', 'nightly'], description: 'Source cluster version to test', name: 'SRC_CLUSTER_VERSION'),
-choice(choices: ['4.3', '3.11', '3.10', '3.9', '3.7', '4.1', '4.2', '4.4', 'nightly'], description: 'Destination cluster version to test', name: 'DEST_CLUSTER_VERSION'),
+parameters([choice(choices: ['3.7', '3.9', '3.10', '3.11', '4.1', '4.2', '4.3', '4.4', 'pre-4.5', 'nightly'], description: 'Source cluster version to test', name: 'SRC_CLUSTER_VERSION'),
+choice(choices: ['4.3', '3.11', '3.10', '3.9', '3.7', '4.1', '4.2', '4.4', 'pre-4.5', 'nightly'], description: 'Destination cluster version to test', name: 'DEST_CLUSTER_VERSION'),
 string(defaultValue: '', description: 'Source cluster API endpoint', name: 'SRC_CLUSTER_URL', trim: false),
 string(defaultValue: '', description: 'Destination cluster API endpoint', name: 'DEST_CLUSTER_URL', trim: false),
 string(defaultValue: '', description: 'AWS region where clusters are deployed', name: 'AWS_REGION', trim: false),

--- a/pipeline/ocp4-base.groovy
+++ b/pipeline/ocp4-base.groovy
@@ -1,7 +1,7 @@
 // ocp4-base.groovy
 properties([
 parameters([
-choice(choices: ['4.4', '4.1', '4.2', '4.3', 'nightly'], description: 'OCP4 version to deploy', name: 'SRC_CLUSTER_VERSION'),
+choice(choices: ['4.4', '4.1', '4.2', '4.3', 'pre-4.5', 'nightly'], description: 'OCP4 version to deploy', name: 'SRC_CLUSTER_VERSION'),
 string(defaultValue: 'jenkins-ci-ocp4-base', description: 'Cluster name to deploy', name: 'CLUSTER_NAME', trim: false),
 string(defaultValue: 'mig-ci@redhat.com', description: 'Email to register the deployment', name: 'EMAIL', trim: false),
 string(defaultValue: '3', description: 'OCP4 master instance count', name: 'OCP4_MASTER_INSTANCE_COUNT', trim: false),

--- a/pipeline/parallel-base.groovy
+++ b/pipeline/parallel-base.groovy
@@ -1,7 +1,7 @@
 // parallel-base.groovy
 properties([
-parameters([choice(choices: ['3.7', '3.9', '3.10', '3.11', '4.1', '4.2', '4.3', '4.4', 'nightly'], description: 'OCP version to deploy on source cluster', name: 'SRC_CLUSTER_VERSION'),
-choice(choices: ['4.4', '3.11', '3.10', '3.9', '3.7', '4.1', '4.2', '4.3', 'nightly'], description: 'OCP version to deploy on destination cluster', name: 'DEST_CLUSTER_VERSION'),
+parameters([choice(choices: ['3.7', '3.9', '3.10', '3.11', '4.1', '4.2', '4.3', '4.4', 'pre-4.5', 'nightly'], description: 'OCP version to deploy on source cluster', name: 'SRC_CLUSTER_VERSION'),
+choice(choices: ['4.4', '3.11', '3.10', '3.9', '3.7', '4.1', '4.2', '4.3', 'pre-4.5', 'nightly'], description: 'OCP version to deploy on destination cluster', name: 'DEST_CLUSTER_VERSION'),
 string(defaultValue: 'jenkins-ci-parallel-base', description: 'Cluster name to deploy', name: 'CLUSTER_NAME', trim: false),
 string(defaultValue: 'mig-ci@redhat.com', description: 'Email to register the deployment', name: 'EMAIL', trim: false),
 string(defaultValue: '1', description: 'OCP3 master instance count', name: 'OCP3_MASTER_INSTANCE_COUNT', trim: false),

--- a/roles/get_ocp_version/tasks/main.yml
+++ b/roles/get_ocp_version/tasks/main.yml
@@ -14,7 +14,8 @@
       '4.1' if k8s_minor_version is version('13', '=') else
       '4.2' if k8s_minor_version is version('14', '=') else
       '4.3' if k8s_minor_version is version('16', '=') else
-      '4.4' if k8s_minor_version is version('17', '>=') }}"
+      '4.4' if k8s_minor_version is version('17', '=') else
+      '4.5' if k8s_minor_version is version('18', '>=') }}"
 
 - set_fact:
     cluster_version: "{{ cluster_version|replace('\"', '') }}"

--- a/roles/ocp4_dump_release/defaults/main.yml
+++ b/roles/ocp4_dump_release/defaults/main.yml
@@ -1,4 +1,4 @@
 openshift_installer_release: "{{ lookup('env', 'OCP4_RELEASE') or 'latest' }}"
 openshift_installer_release_prefix_url: "https://mirror.openshift.com/pub/openshift-v4/clients"
-openshift_parent_dir_choices: { latest-4.1: 'ocp', latest-4.2: 'ocp', latest-4.3: 'ocp', latest-4.4: 'ocp', latest: 'ocp', nightly: 'ocp-dev-preview' }
-openshift_parent_subdir_choices: { latest-4.1: 'latest-4.1', latest-4.2: 'latest-4.2', latest-4.3: 'latest-4.3', latest-4.4: 'latest-4.4', latest: 'latest', nightly: 'latest' }
+openshift_parent_dir_choices: { latest-4.1: 'ocp', latest-4.2: 'ocp', latest-4.3: 'ocp', latest-4.4: 'ocp', pre-4.5: 'ocp', latest: 'ocp', nightly: 'ocp-dev-preview' }
+openshift_parent_subdir_choices: { latest-4.1: 'latest-4.1', latest-4.2: 'latest-4.2', latest-4.3: 'latest-4.3', latest-4.4: 'latest-4.4', pre-4.5: 'candidate-4.5', latest: 'latest', nightly: 'latest' }


### PR DESCRIPTION
- Add job choice parameters and support for OCP 4.5-pre releases to all pipelines
- It will pull latest 4.5 release candidate from https://mirror.openshift.com/pub/openshift-v4/clients/ocp/candidate-4.5/