### PR TITLE
Rename channel from latest to development

### DIFF
--- a/roles/mig_controller_prereqs/templates/mig-operator-subscription.yml.j2
+++ b/roles/mig_controller_prereqs/templates/mig-operator-subscription.yml.j2
@@ -9,7 +9,7 @@ metadata:
   namespace: {{ mig_migration_namespace }}
 spec:
 {% if mig_operator_release == 'latest' %}
-  channel: latest
+  channel: development
 {% else %}
   channel: release-{{ mig_operator_release }}
 {% endif %}


### PR DESCRIPTION
As per https://github.com/konveyor/mig-operator/blob/3a14c1d5093fb2fd6140644d63e09a577d985f08/deploy/olm-catalog/konveyor-operator/konveyor-operator.package.yaml#L3

`latest` channel is renamed to `development`