### PR TITLE
Update OCP v4.7 and older releases

### DIFF
--- a/pipeline/common_stages.groovy
+++ b/pipeline/common_stages.groovy
@@ -10,9 +10,10 @@ def deploy_ocp4_agnosticd(kubeconfig, cluster_version) {
     '4.1': "4.1.41",
     '4.2': "4.2.36",
     '4.3': "4.3.40",
-    '4.4': "4.4.31",
-    '4.5': "4.5.23",
-    '4.6': "4.6.8",
+    '4.4': "4.4.33",
+    '4.5': "4.5.34",
+    '4.6': "4.6.19",
+    '4.7': "4.7.0",
   ]
   def ocp4_installer_version = releases["${cluster_version}"]
   def full_cluster_name = ''

--- a/pipeline/mig-controller-pr-builder.groovy
+++ b/pipeline/mig-controller-pr-builder.groovy
@@ -1,7 +1,7 @@
 // mig-e2e-base.groovy
 properties([
 parameters([choice(choices: ['3.7', '3.9', '3.10', '3.11', '4.1', '4.2', '4.3', '4.4', '4.5', '4.6', 'nightly'], description: 'Source cluster version to test', name: 'SRC_CLUSTER_VERSION'),
-choice(choices: ['4.6', '3.11', '3.10', '3.9', '3.7', '4.1', '4.2', '4.3', '4.4', '4.5', 'nightly'], description: 'Destination cluster version to test', name: 'DEST_CLUSTER_VERSION'),
+choice(choices: ['4.7', '3.11', '3.10', '3.9', '3.7', '4.1', '4.2', '4.3', '4.4', '4.5', '4.6', 'nightly'], description: 'Destination cluster version to test', name: 'DEST_CLUSTER_VERSION'),
 string(defaultValue: '', description: 'Source cluster API endpoint', name: 'SRC_CLUSTER_URL', trim: false),
 string(defaultValue: '', description: 'Destination cluster API endpoint', name: 'DEST_CLUSTER_URL', trim: false),
 string(defaultValue: '', description: 'AWS region where clusters are deployed', name: 'AWS_REGION', trim: false),

--- a/pipeline/ocp4-base.groovy
+++ b/pipeline/ocp4-base.groovy
@@ -1,7 +1,7 @@
 // ocp4-base.groovy
 properties([
 parameters([
-choice(choices: ['4.6', '4.1', '4.2', '4.3', '4.4', '4.5', 'nightly'], description: 'OCP4 version to deploy', name: 'SRC_CLUSTER_VERSION'),
+choice(choices: ['4.7', '4.1', '4.2', '4.3', '4.4', '4.5', '4.6', 'nightly'], description: 'OCP4 version to deploy', name: 'SRC_CLUSTER_VERSION'),
 string(defaultValue: 'jenkins-ci-ocp4-base', description: 'Cluster name to deploy', name: 'CLUSTER_NAME', trim: false),
 string(defaultValue: 'mig-ci@redhat.com', description: 'Email to register the deployment', name: 'EMAIL', trim: false),
 string(defaultValue: '3', description: 'OCP4 master instance count', name: 'OCP4_MASTER_INSTANCE_COUNT', trim: false),

--- a/pipeline/parallel-base.groovy
+++ b/pipeline/parallel-base.groovy
@@ -1,7 +1,7 @@
 // parallel-base.groovy
 properties([
 parameters([choice(choices: ['3.7', '3.9', '3.10', '3.11', '4.1', '4.2', '4.3', '4.4', '4.5', '4.6', 'nightly'], description: 'OCP version to deploy on source cluster', name: 'SRC_CLUSTER_VERSION'),
-choice(choices: ['4.6', '3.11', '3.10', '3.9', '3.7', '4.1', '4.2', '4.3', '4.4', '4.5', 'nightly'], description: 'OCP version to deploy on destination cluster', name: 'DEST_CLUSTER_VERSION'),
+choice(choices: ['4.7', '3.11', '3.10', '3.9', '3.7', '4.1', '4.2', '4.3', '4.4', '4.5', '4.6', 'nightly'], description: 'OCP version to deploy on destination cluster', name: 'DEST_CLUSTER_VERSION'),
 string(defaultValue: 'jenkins-ci-parallel-base', description: 'Cluster name to deploy', name: 'CLUSTER_NAME', trim: false),
 string(defaultValue: 'mig-ci@redhat.com', description: 'Email to register the deployment', name: 'EMAIL', trim: false),
 string(defaultValue: '1', description: 'OCP3 master instance count', name: 'OCP3_MASTER_INSTANCE_COUNT', trim: false),

--- a/roles/ocp4_dump_release/defaults/main.yml
+++ b/roles/ocp4_dump_release/defaults/main.yml
@@ -1,4 +1,4 @@
 openshift_installer_release: "{{ lookup('env', 'OCP4_RELEASE') or 'latest' }}"
 openshift_installer_release_prefix_url: "https://mirror.openshift.com/pub/openshift-v4/clients"
-openshift_parent_dir_choices: { latest-4.1: 'ocp', latest-4.2: 'ocp', latest-4.3: 'ocp', latest-4.4: 'ocp', latest-4.5: 'ocp', latest-4.6: 'ocp', latest: 'ocp', nightly: 'ocp-dev-preview' }
-openshift_parent_subdir_choices: { latest-4.1: 'latest-4.1', latest-4.2: 'latest-4.2', latest-4.3: 'latest-4.3', latest-4.4: 'latest-4.4', latest-4.5: 'latest-4.5', latest-4.6: 'latest-4.6', latest: 'latest', nightly: 'latest' }
+openshift_parent_dir_choices: { latest-4.1: 'ocp', latest-4.2: 'ocp', latest-4.3: 'ocp', latest-4.4: 'ocp', latest-4.5: 'ocp', latest-4.6: 'ocp', latest-4.7: 'ocp', latest: 'ocp', nightly: 'ocp-dev-preview' }
+openshift_parent_subdir_choices: { latest-4.1: 'latest-4.1', latest-4.2: 'latest-4.2', latest-4.3: 'latest-4.3', latest-4.4: 'latest-4.4', latest-4.5: 'latest-4.5', latest-4.6: 'latest-4.6', latest-4.7: 'latest-4.7', latest: 'latest', nightly: 'latest' }


### PR DESCRIPTION
Refresh OCP v4 releases and add OCP v4.7 as a pipeline option